### PR TITLE
test: add e2e test init

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,3 +22,12 @@ make build
 ./cy login --org my-org --email example@email.com --password my-password --api-url https://cycloid-api.local.tld
 ./cy external-backends list
 ```
+
+# Running E2E tests
+
+E2E tests tend to be idempotent as possible but we recommend to use it again a dedicated Cycloid server. Before running the test, you can specify a few environment variables:
+
+  * CY_API_URL: the URL of the Cycloid API server
+  * CY_TEST_EMAIL: the test email
+  * CY_TEST_PASSWORD: the test password
+  * CY_TEST_ORG: the test organization

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -1,0 +1,26 @@
+package e2e
+
+import "os"
+
+var (
+	CY_TEST_EMAIL    = "test@org.local.tld"
+	CY_TEST_PASSWORD = "p4ssw0rd"
+	CY_TEST_ORG      = "e2eOrg"
+)
+
+func init() {
+	email := os.Getenv("CY_TEST_EMAIL")
+	if len(email) > 0 {
+		CY_TEST_EMAIL = email
+	}
+
+	password := os.Getenv("CY_TEST_PASSWORD")
+	if len(password) > 0 {
+		CY_TEST_PASSWORD = password
+	}
+
+	org := os.Getenv("CY_TEST_ORG")
+	if len(org) > 0 {
+		CY_TEST_ORG = org
+	}
+}

--- a/e2e/login_test.go
+++ b/e2e/login_test.go
@@ -1,0 +1,70 @@
+package e2e
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/login"
+)
+
+func TestLogin(t *testing.T) {
+	t.Run("SuccessUserLogin", func(t *testing.T) {
+
+		buf := new(bytes.Buffer)
+
+		cmd := login.NewCommands()
+		cmd.SetOut(buf)
+		cmd.SetArgs([]string{
+			"--email", CY_TEST_EMAIL,
+			"--password", CY_TEST_PASSWORD,
+		})
+
+		cmd.Execute()
+
+		out, err := ioutil.ReadAll(buf)
+		require.Nil(t, err)
+
+		assert.Equal(t, out, []byte(""))
+	})
+	t.Run("SuccessOrgLogin", func(t *testing.T) {
+
+		buf := new(bytes.Buffer)
+
+		cmd := login.NewCommands()
+		cmd.SetOut(buf)
+		cmd.SetArgs([]string{
+			"--org", CY_TEST_ORG,
+			"--email", CY_TEST_EMAIL,
+			"--password", CY_TEST_PASSWORD,
+		})
+
+		cmd.Execute()
+
+		out, err := ioutil.ReadAll(buf)
+		require.Nil(t, err)
+
+		assert.Equal(t, out, []byte(""))
+	})
+	t.Run("ErrorMissingRequiredFlag", func(t *testing.T) {
+
+		buf := new(bytes.Buffer)
+
+		cmd := login.NewCommands()
+		cmd.SetOut(buf)
+		cmd.SetArgs([]string{
+			"--org", CY_TEST_ORG,
+			"--password", CY_TEST_PASSWORD,
+		})
+
+		cmd.Execute()
+
+		out, err := ioutil.ReadAll(buf)
+		require.Nil(t, err)
+
+		assert.Contains(t, string(out), string([]byte(`required flag(s) "email" not set`)))
+	})
+}


### PR DESCRIPTION
Initial PR to kickstart the E2E tests. 

What I have in mind: 

We should provide a simple SQL dump (with a user) and load a database with this dump. Once done, we can run the e2e tests against a dev Cycloid API server (up in the CI). 

Closes: https://github.com/cycloidio/cycloid-cli/issues/13