### PR TITLE
cmd/login: be able to log into a child organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
    ([PR #25](https://github.com/cycloidio/cycloid-cli/pull/25))
   - `login list` subcommand
    ([PR #24](https://github.com/cycloidio/cycloid-cli/pull/24))
+  - support for child org login
+   ([PR #37](https://github.com/cycloidio/cycloid-cli/pull/37))
 
 ## [v1.0.47] _2020-09-21_
 - **ADDED**

--- a/cmd/cycloid/middleware/login.go
+++ b/cmd/cycloid/middleware/login.go
@@ -33,10 +33,13 @@ func (m *middleware) Login(email, password string) (*models.UserSession, error) 
 	return res.GetPayload().Data, nil
 }
 
-func (m *middleware) LoginOrg(org, username, password string) (*models.UserSession, error) {
+func (m *middleware) LoginOrg(org, child, username, password string) (*models.UserSession, error) {
 
 	params := user.NewRefreshTokenParams()
 	params.SetOrganizationCanonical(&org)
+	if len(child) != 0 {
+		params.SetChildCanonical(&child)
+	}
 	res, err := m.api.User.RefreshToken(params, common.ClientCredentials(nil))
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to log user")

--- a/cmd/cycloid/middleware/middleware.go
+++ b/cmd/cycloid/middleware/middleware.go
@@ -65,7 +65,7 @@ type Middleware interface {
 	Login(email, password string) (*models.UserSession, error)
 
 	// LoginOrg is the used to log the user into a Cycloid organization
-	LoginOrg(org, email, password string) (*models.UserSession, error)
+	LoginOrg(org, child, email, password string) (*models.UserSession, error)
 
 	ListMembers(org string) ([]*models.MemberOrg, error)
 	GetMember(org string, name string) (*models.MemberOrg, error)


### PR DESCRIPTION
the API call requires to pass the "main org" and the "child org" to be able to login into the child org. [doc](https://docs.cycloid.io/api/index.html#operation/refreshToken)