### PR TITLE
cmd/status:  endpoint implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
    ([PR #24](https://github.com/cycloidio/cycloid-cli/pull/24))
   - support for child org login
    ([PR #37](https://github.com/cycloidio/cycloid-cli/pull/37))
+  - status endpoint implementation
+   ([PR #42](https://github.com/cycloidio/cycloid-cli/pull/42))
 
 ## [v1.0.47] _2020-09-21_
 - **ADDED**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ cy login --org my-org --email example@email.com --password my-password --api-url
 From there, you can now explore the various commands using the `--help` flag for each command / subcommand.
 
 ```shell
-$ cy help
+$ ./cy help
 Cy is a CLI for Cycloid framework. Learn more at https://www.cycloid.io/.
 
 Usage:
@@ -31,7 +31,10 @@ Available Commands:
   organization       Manage the organizations
   pipeline           Manage the pipelines
   project            Manage the projects
+  roles              Manage roles from the organization
   stack              Manage the stacks
+  status             Get the status of the Cycloid services
+  validate-form      validate a .forms.yml file
   version            Get the version of the consumed API
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ You can download the latest Linux binary from the [release](https://github.com/c
 
 ## Common actions
 
+### Get the Cycloid services in an unhealthy state
+
+```
+cy status -o json | jq '.[] | select( .status != "Success")'
+```
+
 :construction:
 <!-- This is where we could add some useful examples: create a user, etc. -->
 

--- a/cmd/cycloid.go
+++ b/cmd/cycloid.go
@@ -30,10 +30,9 @@ func init() {
 func AttachCommands(cmd *cobra.Command) {
 	cmd.AddCommand(
 		// Root
-		root.NewStatusCmd(),
 		root.NewVersionCmd(),
 		root.NewValidateFormCmd(),
-		organizations.NewCommands(),
+		root.NewStatusCmd(),
 		catalogRepositories.NewCommands(),
 		configRepositories.NewCommands(),
 		creds.NewCommands(),

--- a/cmd/cycloid/middleware/cycloid.go
+++ b/cmd/cycloid/middleware/cycloid.go
@@ -1,10 +1,13 @@
 package middleware
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/cycloidio/cycloid-cli/client/client/cycloid"
 	"github.com/cycloidio/cycloid-cli/client/models"
 )
 
+// GetAppVersion returns the version of the running Cycloid server
 func (m *middleware) GetAppVersion() (*models.AppVersion, error) {
 
 	params := cycloid.NewGetAppVersionParams()
@@ -15,13 +18,20 @@ func (m *middleware) GetAppVersion() (*models.AppVersion, error) {
 	}
 
 	p := resp.GetPayload()
-	// TODO this validate have been removed https://github.com/cycloidio/youdeploy-http-api/issues/2262
-	// err = p.Validate(strfmt.Default)
-	// if err != nil {
-	// 	return err
-	// }
 
 	d := p.Data
 
 	return d, err
+}
+
+// GetStatus returns the status of the various Cycloid services
+func (m *middleware) GetStatus() (*models.GeneralStatus, error) {
+	resp, err := m.api.Cycloid.GetStatus(nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get answer from the API")
+	}
+
+	p := resp.GetPayload()
+
+	return p.Data, err
 }

--- a/cmd/cycloid/middleware/middleware.go
+++ b/cmd/cycloid/middleware/middleware.go
@@ -8,6 +8,7 @@ import (
 
 type Middleware interface {
 	GetAppVersion() (*models.AppVersion, error)
+	GetStatus() (*models.GeneralStatus, error)
 
 	CreateCatalogRepository(org, name, url, branch string, cred uint32) (*models.ServiceCatalogSource, error)
 	DeleteCatalogRepository(org string, catalogRepo uint32) error

--- a/cmd/cycloid/status.go
+++ b/cmd/cycloid/status.go
@@ -1,23 +1,81 @@
 package root
 
 import (
-	"fmt"
+	"os"
 
-	"github.com/cycloidio/cycloid-cli/cmd/cycloid/internal"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/internal"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/printer"
+	"github.com/cycloidio/cycloid-cli/printer/factory"
 )
 
 func NewStatusCmd() *cobra.Command {
-	var cmd = &cobra.Command{
-		Use:     "status",
-		Hidden:  true,
-		Short:   "not implemented yet",
-		Long:    `not implemented yet`,
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Get the status of the Cycloid services",
+		Example: `
+	# show the status of Cycloid services
+	cy status
+`,
 		PreRunE: internal.CheckAPIAndCLIVersion,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println("not implemented yet")
-			return nil
+			output, err := cmd.Flags().GetString("output")
+			if err != nil {
+				return errors.Wrap(err, "unable to get output flag")
+			}
+
+			return status(output)
 		},
 	}
-	return cmd
+
+}
+
+func status(output string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	services, err := m.GetStatus()
+	if err != nil {
+		return errors.Wrap(err, "unable to get status")
+	}
+
+	// for a better table display, we process the result
+	// in order to add some colors following the service
+	// state
+	if output == "table" {
+		var (
+			// green
+			success = "\033[0;32mSuccess\033[0m"
+			// orange
+			unknown = "\033[0;33mUnknown\033[0m"
+			// red
+			err = "\033[0;31mError\033[0m"
+		)
+		for _, service := range services.Checks {
+			switch *service.Status {
+			case "Success":
+				service.Status = &success
+			case "Unknown":
+				service.Status = &unknown
+			case "Error":
+				service.Status = &err
+			}
+		}
+	}
+
+	// fetch the printer from the factory
+	p, err := factory.GetPrinter(output)
+	if err != nil {
+		return errors.Wrap(err, "unable to get printer")
+	}
+
+	// print the result on the standard output
+	if err := p.Print(services.Checks, printer.Options{}, os.Stdout); err != nil {
+		return errors.Wrap(err, "unable to print result")
+	}
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,11 @@ go 1.14
 
 require (
 	github.com/adrg/xdg v0.2.1
-	github.com/coreos/dex v2.13.0+incompatible
-	github.com/davecgh/go-spew v1.1.1
 	github.com/go-openapi/errors v0.19.6
 	github.com/go-openapi/runtime v0.19.20
 	github.com/go-openapi/strfmt v0.19.5
 	github.com/go-openapi/swag v0.19.9
 	github.com/go-openapi/validate v0.19.10
-	github.com/markbates/pkger v0.17.1
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -22,9 +22,6 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
-github.com/coreos/dex v0.6.1 h1:tLWJUguiBRT0L5+P1SipllJphz1fnVl6GaPGL1ypqEQ=
-github.com/coreos/dex v2.13.0+incompatible h1:iwTFQFV7PnQ91+vSVhXGWdzEcF4I+U52DgEGDrwGWfk=
-github.com/coreos/dex v2.13.0+incompatible/go.mod h1:eWiVFa+I1sIRiwXi4bJMZvd90+H7EhRm/J1Y6Y18AOM=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
@@ -129,8 +126,6 @@ github.com/gobuffalo/gitgen v0.0.0-20190315122116-cc086187d211/go.mod h1:vEHJk/E
 github.com/gobuffalo/gogen v0.0.0-20190315121717-8f38393713f5/go.mod h1:V9QVDIxsgKNZs6L2IYiGR8datgMhB577vzTDqypH360=
 github.com/gobuffalo/gogen v0.1.0/go.mod h1:8NTelM5qd8RZ15VjQTFkAW6qOMx5wBbW4dSCS3BY8gg=
 github.com/gobuffalo/gogen v0.1.1/go.mod h1:y8iBtmHmGc4qa3urIyo1shvOD8JftTtfcKi+71xfDNE=
-github.com/gobuffalo/here v0.6.0 h1:hYrd0a6gDmWxBM4TnrGw8mQg24iSVoIkHEk7FodQcBI=
-github.com/gobuffalo/here v0.6.0/go.mod h1:wAG085dHOYqUpf+Ap+WOdrPTp5IYcDAs/x7PLa8Y5fM=
 github.com/gobuffalo/logger v0.0.0-20190315122211-86e12af44bc2/go.mod h1:QdxcLw541hSGtBnhUc4gaNIXRjiDppFGaDqzbrBd3v8=
 github.com/gobuffalo/mapi v1.0.1/go.mod h1:4VAGh89y6rVOvm5A8fKFxYG+wIW6LO1FMTG9hnKStFc=
 github.com/gobuffalo/mapi v1.0.2/go.mod h1:4VAGh89y6rVOvm5A8fKFxYG+wIW6LO1FMTG9hnKStFc=
@@ -189,8 +184,6 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.1 h1:mdxE1MF9o53iCb2Ghj1VfWvh7ZOwHpnVG/xwXrV90U8=
 github.com/mailru/easyjson v0.7.1/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
-github.com/markbates/pkger v0.17.1 h1:/MKEtWqtc0mZvu9OinB9UzVN9iYCwLWuyUv4Bw+PCno=
-github.com/markbates/pkger v0.17.1/go.mod h1:0JoVlrol20BSywW79rN3kdFFsE5xYM+rSCQDXbLhiuI=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
@@ -361,7 +354,6 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Initial implementation of the `/status` endpoint. With colors on the table display

![output](https://pastefile-owl.cycloid.io/05549c8fca1fb3bfe72d00facd02acf2)

Closes: https://github.com/cycloidio/cycloid-cli/issues/27