### PR TITLE
cmd/cycloid/login: use standard cmd notation

### DIFF
--- a/cmd/cycloid.go
+++ b/cmd/cycloid.go
@@ -44,6 +44,6 @@ func AttachCommands(cmd *cobra.Command) {
 		projects.NewCommands(),
 		roles.NewCommands(),
 		stacks.NewCommands(),
-		login.LoginCmd,
+		login.NewCommands(),
 	)
 }

--- a/cmd/cycloid/creds/create.go
+++ b/cmd/cycloid/creds/create.go
@@ -59,7 +59,7 @@ func NewCreateCommand() *cobra.Command {
 		PreRunE: internal.CheckAPIAndCLIVersion,
 		Example: `
 	# create a credential for custom type
-	cy --my-org credential create custom --my-key=my-value
+	cy --my-org credential create custom --field my-key=my-value --field my-key2=my-value2
 `,
 	}
 	common.RequiredFlag(WithFlagField, custom)

--- a/cmd/cycloid/login/common.go
+++ b/cmd/cycloid/login/common.go
@@ -1,0 +1,26 @@
+package login
+
+import "github.com/spf13/cobra"
+
+var (
+	org      string
+	email    string
+	password string
+	child    string
+)
+
+func WithFlagOrg(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&org, "org", "", "organization name")
+}
+
+func WithFlagEmail(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&email, "email", "", "email")
+}
+
+func WithFlagPassword(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&password, "password", "", "password")
+}
+
+func WithFlagChild(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&child, "child", "", "child organization")
+}

--- a/cmd/cycloid/login/list.go
+++ b/cmd/cycloid/login/list.go
@@ -11,8 +11,10 @@ import (
 	"github.com/cycloidio/cycloid-cli/printer/factory"
 )
 
-var (
-	list = &cobra.Command{
+// NewListCommand returns the cobra command holding
+// the list login subcommand
+func NewListCommand() *cobra.Command {
+	return &cobra.Command{
 		Use:   "list",
 		Short: "list the current logged organizations",
 		Example: `
@@ -24,40 +26,44 @@ var (
 			if err != nil {
 				return errors.Wrap(err, "unable to get output flag")
 			}
-			// fetch any existing config
-			// we skip the error in case it's the first usage and the config
-			// file does not exist
-			conf, _ := config.ReadConfig()
-
-			// we need to peform this hack because the printer is waiting for
-			// a struct or a slice of structs. Not a map, since the header of the table
-			// is the name of the field, we need to pass to the printer a slice of anonymous
-			// struct
-			var orgs []*struct {
-				Name  string
-				Token string
-			}
-			for name, o := range conf.Organizations {
-				orgs = append(orgs, &struct {
-					Name  string
-					Token string
-				}{
-					Name:  name,
-					Token: o.Token,
-				})
-			}
-
-			// fetch the printer from the factory
-			p, err := factory.GetPrinter(output)
-			if err != nil {
-				return errors.Wrap(err, "unable to get printer")
-			}
-
-			// print the result on the standard output
-			if err := p.Print(orgs, printer.Options{}, os.Stdout); err != nil {
-				return errors.Wrap(err, "unable to print result")
-			}
-			return nil
+			return list(output)
 		},
 	}
-)
+}
+
+func list(output string) error {
+	// fetch any existing config
+	// we skip the error in case it's the first usage and the config
+	// file does not exist
+	conf, _ := config.ReadConfig()
+
+	// we need to peform this hack because the printer is waiting for
+	// a struct or a slice of structs. Not a map, since the header of the table
+	// is the name of the field, we need to pass to the printer a slice of anonymous
+	// struct
+	var orgs []*struct {
+		Name  string
+		Token string
+	}
+	for name, o := range conf.Organizations {
+		orgs = append(orgs, &struct {
+			Name  string
+			Token string
+		}{
+			Name:  name,
+			Token: o.Token,
+		})
+	}
+
+	// fetch the printer from the factory
+	p, err := factory.GetPrinter(output)
+	if err != nil {
+		return errors.Wrap(err, "unable to get printer")
+	}
+
+	// print the result on the standard output
+	if err := p.Print(orgs, printer.Options{}, os.Stdout); err != nil {
+		return errors.Wrap(err, "unable to print result")
+	}
+	return nil
+}

--- a/cmd/cycloid/login/login.go
+++ b/cmd/cycloid/login/login.go
@@ -10,8 +10,13 @@ import (
 	"github.com/cycloidio/cycloid-cli/config"
 )
 
-var (
-	example = `
+// NewCommands returns the cobra command holding
+// the login command / subcommands
+func NewCommands() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "login",
+		Short: "Login against the Cycloid console",
+		Example: `,
 	# Login into my-org using email / password as flags
 	cy login --org my-org --email my-email --password my-password
 
@@ -20,20 +25,10 @@ var (
 
 	# Login in a org child of an organization
 	cy login --org my-org --child child-org  --email my-email --password my-password
-`
-	short    = "Login against the Cycloid console"
-	long     = short
-	org      string
-	email    string
-	password string
-	child    string
-	LoginCmd = &cobra.Command{
-		Use:     "login",
-		Short:   short,
-		Long:    long,
-		Example: example,
+`,
 		PreRunE: internal.CheckAPIAndCLIVersion,
 		RunE: func(cmd *cobra.Command, args []string) error {
+
 			org, err := cmd.Flags().GetString("org")
 			if err != nil {
 				return errors.Wrap(err, "unable to get org flag")
@@ -51,64 +46,72 @@ var (
 				return errors.Wrap(err, "unable to get child flag")
 			}
 
-			api := common.NewAPI()
-			m := middleware.NewMiddleware(api)
-
-			// we first need to authenticate the user against cycloid console
-			session, err := m.Login(email, password)
-			if err != nil {
-				return errors.Wrapf(err, "unable to log user: %s", email)
-			}
-
-			// fetch any existing config
-			// we skip the error in case it's the first usage and the config
-			// file does not exist
-			conf, _ := config.ReadConfig()
-
-			// we save the new generated token into the config file
-			conf.Token = *session.Token
-			if err := config.WriteConfig(conf); err != nil {
-				return errors.Wrap(err, "unable to save config")
-			}
-
-			if len(org) != 0 {
-				orgSession, err := m.LoginOrg(org, child, email, password)
-				if err != nil {
-					return errors.Wrapf(err, "unable to log user: %s", email)
-				}
-
-				// we save the new generated token and remove the previous one
-				conf, err := config.ReadConfig()
-				if err != nil {
-					return errors.Wrap(err, "unable to read config: %s")
-				}
-				// there is no distinction between child or "root" org, we just
-				// need to save it once
-				// if the org and child are given, we save only the child token
-				// else we save the org token
-				if len(child) != 0 {
-					conf.Organizations[child] = config.Organization{
-						Token: *orgSession.Token,
-					}
-				} else {
-					conf.Organizations[org] = config.Organization{
-						Token: *orgSession.Token,
-					}
-				}
-				if err := config.WriteConfig(conf); err != nil {
-					return errors.Wrap(err, "unable to save config")
-				}
-			}
-			return nil
+			return login(org, child, email, password)
 		},
 	}
-)
 
-func init() {
-	LoginCmd.PersistentFlags().StringVar(&org, "org", "", "organization")
-	LoginCmd.PersistentFlags().StringVar(&email, "email", "", "email")
-	LoginCmd.PersistentFlags().StringVar(&password, "password", "", "password")
-	LoginCmd.PersistentFlags().StringVar(&child, "child", "", "child organization canonical")
+	WithFlagOrg(cmd)
+	WithFlagEmail(cmd)
+	WithFlagPassword(cmd)
+	WithFlagChild(cmd)
+	cmd.MarkFlagRequired("email")
+	cmd.MarkFlagRequired("password")
 
-	LoginCmd.AddCommand(list)
+	cmd.AddCommand(
+		NewListCommand(),
+	)
+
+	return cmd
+}
+
+func login(org, child, email, password string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	// we first need to authenticate the user against cycloid console
+	session, err := m.Login(email, password)
+	if err != nil {
+		return errors.Wrapf(err, "unable to log user: %s", email)
+	}
+
+	// fetch any existing config
+	// we skip the error in case it's the first usage and the config
+	// file does not exist
+	conf, _ := config.ReadConfig()
+
+	// we save the new generated token into the config file
+	conf.Token = *session.Token
+	if err := config.WriteConfig(conf); err != nil {
+		return errors.Wrap(err, "unable to save config")
+	}
+
+	if len(org) != 0 {
+		orgSession, err := m.LoginOrg(org, child, email, password)
+		if err != nil {
+			return errors.Wrapf(err, "unable to log user: %s", email)
+		}
+
+		// we save the new generated token and remove the previous one
+		conf, err := config.ReadConfig()
+		if err != nil {
+			return errors.Wrap(err, "unable to read config: %s")
+		}
+		// there is no distinction between child or "root" org, we just
+		// need to save it once
+		// if the org and child are given, we save only the child token
+		// else we save the org token
+		if len(child) != 0 {
+			conf.Organizations[child] = config.Organization{
+				Token: *orgSession.Token,
+			}
+		} else {
+			conf.Organizations[org] = config.Organization{
+				Token: *orgSession.Token,
+			}
+		}
+		if err := config.WriteConfig(conf); err != nil {
+			return errors.Wrap(err, "unable to save config")
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
following our discussion, I reworded this part to use the common notation.