### PR TITLE
cmd: add auto complete (bash | zsh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
    ([PR #37](https://github.com/cycloidio/cycloid-cli/pull/37))
   - status endpoint implementation
    ([PR #42](https://github.com/cycloidio/cycloid-cli/pull/42))
+  - bash/zsh auto-complete
+   ([PR #47](https://github.com/cycloidio/cycloid-cli/pull/47))
 
 ## [v1.0.47] _2020-09-21_
 - **ADDED**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ cy login --org my-org --email example@email.com --password my-password --api-url
 From there, you can now explore the various commands using the `--help` flag for each command / subcommand.
 
 ```shell
-$ ./cy help
+$ cy help
 Cy is a CLI for Cycloid framework. Learn more at https://www.cycloid.io/.
 
 Usage:
@@ -21,6 +21,7 @@ Usage:
 
 Available Commands:
   catalog-repository Manage the catalog repositories
+  completion         Output shell completion for the given shell (bash or zsh)
   config-repository  Manage the catalog repositories
   credential         Manage the credentials
   event              Manage the events

--- a/cmd/cycloid.go
+++ b/cmd/cycloid.go
@@ -33,6 +33,7 @@ func AttachCommands(cmd *cobra.Command) {
 		root.NewVersionCmd(),
 		root.NewValidateFormCmd(),
 		root.NewStatusCmd(),
+		root.NewCompletionCmd(),
 		catalogRepositories.NewCommands(),
 		configRepositories.NewCommands(),
 		creds.NewCommands(),

--- a/cmd/cycloid/completion.go
+++ b/cmd/cycloid/completion.go
@@ -1,0 +1,42 @@
+package root
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// NewCompletionCmd returns the cobra command that outputs shell completion code
+func NewCompletionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use: "completion (zsh|bash)",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return fmt.Errorf("requires 1 arg, found %d", len(args))
+			}
+			return cobra.OnlyValidArgs(cmd, args)
+		},
+		ValidArgs: []string{"bash", "zsh"},
+		Short:     "Output shell completion for the given shell (bash or zsh)",
+		RunE:      completion,
+		Example: `
+	# generate completion for ZSH
+	cy completion zsh > _cy; cp _cy ~/.oh-my-zsh/functions; source ~/.zshrc
+
+	# generate completion for Bash
+	cy completion bash > cy; sudo cp cy /etc/bash_completion.d/; source /etc/profile
+`,
+	}
+}
+
+func completion(cmd *cobra.Command, args []string) error {
+	switch args[0] {
+	case "bash":
+		return cmd.Root().GenBashCompletion(os.Stdout)
+	case "zsh":
+		return cmd.Root().GenZshCompletion(os.Stdout)
+	default:
+		return nil
+	}
+}

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func init() {
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 
-	rootCmd.PersistentFlags().StringVarP(&userOutput, "output", "o", "table", "The formatting style for command output [json|yaml|table].")
+	rootCmd.PersistentFlags().StringVarP(&userOutput, "output", "o", "table", "The formatting style for command output: json|yaml|table")
 	viper.BindPFlag("output", rootCmd.PersistentFlags().Lookup("output"))
 
 	rootCmd.PersistentFlags().StringP("verbosity", "v", "warning", "Override the default verbosity for this command. VERBOSITY must be one of: debug, info, warning, error, critical, none.")


### PR DESCRIPTION
Use `cobra` bash/zsh generation. 

[demo asciinema](https://asciinema.org/a/n8evC60FvgCvq2IQ7WDRGgfHs)

:warning: the `[` / `]` are not escaped in the flag description which leads to error, that's why I modified the `--output` flag description but we could have this error elsewhere. :) 

Closes: https://github.com/cycloidio/cycloid-cli/issues/22