### PR TITLE
Adding cy wrapper

### DIFF
--- a/cmd/cycloid/projects/create-env.go
+++ b/cmd/cycloid/projects/create-env.go
@@ -28,7 +28,7 @@ func NewCreateEnvCommand() *cobra.Command {
 		--usecase usecase-1 \
 		--pipeline /my/pipeline.yml \
 		--vars /my/pipeline/vars.yml \
-		--config /my/config/path.yml
+		--config /path/to/config=/path/in/config_repo
 `,
 		PreRunE: internal.CheckAPIAndCLIVersion,
 		RunE:    createEnv,

--- a/cmd/cycloid/projects/create.go
+++ b/cmd/cycloid/projects/create.go
@@ -23,7 +23,6 @@ func NewCreateCommand() *cobra.Command {
 	# create a project
 	cy --org my-org project create \
 		--name my-project \
-		--canonical my-project \
 		--description "an awesome project" \
 		--cloud-provider gcp|aws|... \
 		--stack-ref my-stack-ref \
@@ -32,7 +31,7 @@ func NewCreateCommand() *cobra.Command {
 		--usecase usecase-1 \
 		--vars /path/to/variables.yml \
 		--pipeline /path/to/pipeline.yml \
-		--config /path/to/config
+		--config /path/to/config=/path/in/config_repo
 `,
 		RunE:    create,
 		PreRunE: internal.CheckAPIAndCLIVersion,

--- a/scripts/cy-wrapper.sh
+++ b/scripts/cy-wrapper.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# Warning: this script is expected to be used in cycloid-toolkit docker image.
+# We do not recommand to use it in another context.
+
+if test -z "$BASH_VERSION"; then
+  echo "Please run this script using bash, not sh or any other shell." >&2
+  exit 1
+fi
+
+export CY_API_URL="${CY_API_URL:-https://http-api.cycloid.io}"
+export CY_BINARIES_PATH="${CY_BINARIES_PATH:-/usr/local/bin}"
+
+# Ensure we have Cycloid directory created
+if ! [ -d "$CY_BINARIES_PATH" ]; then
+  mkdir -p "$CY_BINARIES_PATH"
+fi
+
+# If specified in the commandline use it
+if [[ $(echo "$@" | grep -E --  "--api-url(=|\s+)([^\]+)") ]]; then
+  CY_API_URL=$(echo "$@" | sed -r "s/.*--api-url(=|\s+)([^ ]+).*/\2/")
+fi
+
+# Remove trailing /
+CY_API_URL=${CY_API_URL%/}
+
+# Get Cycloid API version
+export CY_VERSION=$(curl -s "${CY_API_URL}/version" | jq -r .data.version)
+
+if [[ -z "$CY_VERSION" ]]; then
+  echo "Error: Unable to get Cycloid API version on ${CY_API_URL}/version"
+  exit 1
+fi
+
+# Download the binary if not present
+export CY_BINARY="${CY_BINARIES_PATH}/cy-${CY_VERSION}"
+if ! [[ -f "${CY_BINARY}" ]]; then
+
+  CY_URL="https://github.com/cycloidio/cycloid-cli/releases/download/v${CY_VERSION}/cy"
+  wget -q -O "${CY_BINARY}" "$CY_URL"
+  STATUS=$?
+
+  if [ $STATUS != 0 ]; then
+    rm -f "${CY_BINARY}"
+  fi
+
+  # In case of 404, fallback on latest develop version
+  if [ $STATUS == 8 ]; then
+    echo "Warning: Unable to download CLI version ${CY_VERSION}. Fallback to latest develop version"
+    CY_BINARY="${CY_BINARIES_PATH}/cy-latest"
+    CY_URL="https://github.com/cycloidio/cycloid-cli/releases/download/v0.0-dev/cy"
+    wget -q -O "${CY_BINARY}" "$CY_URL"
+    STATUS=$?
+  fi
+
+  if [ $STATUS != 0 ]; then
+    echo "Error: Unable to download Cycloid CLI from github ${CY_URL}"
+    exit 1
+  fi
+  chmod +x "${CY_BINARY}"
+fi
+
+# Run Cycloid CLI
+exec "${CY_BINARY}" "$@"


### PR DESCRIPTION
Just to sum up, this wrapper will be used in our `cycloid-toolkit` docker image.
We don't recommend or expect users to use this on their laptops (we have another plan for them).

So our usage context should be a docker image used in a pipeline.

**pipeline** (wrapper)

The main goal is to be able to store the last X (3) version of our `cy` binary in cache (in the docker image).
Then the wrapper will use them. If not present it will download them.

**regular users**

My current idea for users is to migrate the download part in the actual CLI. The same way as fly for concourse.

The user will have only one `cy` binary. They don't need a wrapper to store and download X version of this binary

The user will run something like `cy sync` which will actually download the appropriated version of the binary vs the API you are using. And put it under your `cy` path
For now we just have a warning message and the user have to do it manually.

