### PR TITLE
cmd: add `api-key` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 - **ADDED**
   - Add organization create/delete
    ([PR #51](https://github.com/cycloidio/cycloid-cli/pull/51))
+  - `api-keys` commands
+   ([PR #57](https://github.com/cycloidio/cycloid-cli/pull/57))
+
+- **CHANGED**
+  - `login` method to allow login using API key
+   ([PR #57](https://github.com/cycloidio/cycloid-cli/pull/57))
 
 ## [v1.0.49] _2020-11-02_
 - **ADDED**

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Usage:
   cy [command]
 
 Available Commands:
+  api-key            Manage organization API keys
   catalog-repository Manage the catalog repositories
   completion         Output shell completion for the given shell (bash or zsh)
   config-repository  Manage the catalog repositories

--- a/cmd/cycloid.go
+++ b/cmd/cycloid.go
@@ -1,9 +1,8 @@
-// Change the package name because it it not a go plugin anymore
-// package main
 package cmd
 
 import (
 	root "github.com/cycloidio/cycloid-cli/cmd/cycloid"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/apikey"
 	catalogRepositories "github.com/cycloidio/cycloid-cli/cmd/cycloid/catalog-repositories"
 	configRepositories "github.com/cycloidio/cycloid-cli/cmd/cycloid/config-repositories"
 	"github.com/cycloidio/cycloid-cli/cmd/cycloid/creds"
@@ -34,6 +33,7 @@ func AttachCommands(cmd *cobra.Command) {
 		root.NewValidateFormCmd(),
 		root.NewStatusCmd(),
 		root.NewCompletionCmd(),
+		apikey.NewCommands(),
 		catalogRepositories.NewCommands(),
 		configRepositories.NewCommands(),
 		creds.NewCommands(),

--- a/cmd/cycloid/apikey/cmd.go
+++ b/cmd/cycloid/apikey/cmd.go
@@ -27,8 +27,9 @@ func NewCommands() *cobra.Command {
 	}
 	common.RequiredPersistentFlag(common.WithFlagOrg, cmd)
 
-	cmd.AddSubcommand(
-		NewCreateCommand,
+	cmd.AddCommand(
+		NewCreateCommand(),
+		NewListCommand(),
 	)
 	return cmd
 }

--- a/cmd/cycloid/apikey/cmd.go
+++ b/cmd/cycloid/apikey/cmd.go
@@ -26,5 +26,9 @@ func NewCommands() *cobra.Command {
 		Hidden:  true,
 	}
 	common.RequiredPersistentFlag(common.WithFlagOrg, cmd)
+
+	cmd.AddSubcommand(
+		NewCreateCommand,
+	)
 	return cmd
 }

--- a/cmd/cycloid/apikey/cmd.go
+++ b/cmd/cycloid/apikey/cmd.go
@@ -1,0 +1,30 @@
+package apikey
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+)
+
+var (
+	example = `
+	# Manage API keys of my-org organization
+	cy --org my-org api-key [create|list|get|delete]
+`
+	short = "Manage organization API keys"
+)
+
+func NewCommands() *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "api-key",
+		Aliases: []string{
+			"api-keys",
+			"ak",
+		},
+		Example: example,
+		Short:   short,
+		Hidden:  true,
+	}
+	common.RequiredPersistentFlag(common.WithFlagOrg, cmd)
+	return cmd
+}

--- a/cmd/cycloid/apikey/cmd.go
+++ b/cmd/cycloid/apikey/cmd.go
@@ -29,6 +29,7 @@ func NewCommands() *cobra.Command {
 
 	cmd.AddCommand(
 		NewCreateCommand(),
+		NewGetCommand(),
 		NewListCommand(),
 	)
 	return cmd

--- a/cmd/cycloid/apikey/cmd.go
+++ b/cmd/cycloid/apikey/cmd.go
@@ -29,6 +29,7 @@ func NewCommands() *cobra.Command {
 
 	cmd.AddCommand(
 		NewCreateCommand(),
+		NewDeleteCommand(),
 		NewGetCommand(),
 		NewListCommand(),
 	)

--- a/cmd/cycloid/apikey/common.go
+++ b/cmd/cycloid/apikey/common.go
@@ -1,0 +1,26 @@
+package apikey
+
+import "github.com/spf13/cobra"
+
+var (
+	canonical   string
+	name        string
+	description string
+	roleID      uint32
+)
+
+func WithFlagName(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&name, "name", "", "name of the API key")
+}
+
+func WithFlagDescription(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&description, "description", "", "description of the API key")
+}
+
+func WithFlagRoleID(cmd *cobra.Command) {
+	cmd.Flags().Uint32Var(&roleID, "role-id", 0, "ID of the role")
+}
+
+func WithFlagCanonical(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&canonical, "canonical", "", "canonical of the API key")
+}

--- a/cmd/cycloid/apikey/create.go
+++ b/cmd/cycloid/apikey/create.go
@@ -1,0 +1,88 @@
+package apikey
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/printer"
+	"github.com/cycloidio/cycloid-cli/printer/factory"
+)
+
+// NewCreateCommand returns the cobra command holding
+// the create API key subcommand
+func NewCreateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "create an API key",
+		Example: `
+	# create an API key in the org my-org
+	cy api-key create --role-id 2 --name "CI API key" --description "Cycloid API key to be used in a CI context"
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			output, err := cmd.Flags().GetString("output")
+			if err != nil {
+				return fmt.Errorf("unable to get output flag: %w", err)
+			}
+			name, err := cmd.Flags().GetString("name")
+			if err != nil {
+				return fmt.Errorf("unable to get name flag: %w", err)
+			}
+			description, err := cmd.Flags().GetString("description")
+			if err != nil {
+				return fmt.Errorf("unable to get description flag: %w", err)
+			}
+			roleID, err := cmd.Flags().GetUint32("role-id")
+			if err != nil {
+				return fmt.Errorf("unable to get role ID flag: %w", err)
+			}
+			canonical, err := cmd.Flags().GetString("canonical")
+			if err != nil {
+				return fmt.Errorf("unable to get canonical flag: %w", err)
+			}
+			org, err := cmd.Flags().GetString("org")
+			if err != nil {
+				return fmt.Errorf("unable to get org flag: %w", err)
+			}
+			return create(org, name, canonical, description, output, roleID)
+		},
+	}
+
+	WithFlagName(cmd)
+	WithFlagDescription(cmd)
+	WithFlagRoleID(cmd)
+	WithFlagCanonical(cmd)
+
+	return cmd
+}
+
+// create will send the POST request to the API in order to
+// create an API token which will be displayed on the screen
+func create(org, name, canonical, description, output string, roleID uint32) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	if len(canonical) == 0 {
+		canonical = common.GenerateCanonical(name)
+	}
+
+	key, err := m.CreateAPIKey(org, name, canonical, description, roleID)
+	if err != nil {
+		return fmt.Errorf("unable to create API key: %w", err)
+	}
+
+	// fetch the printer from the factory
+	p, err := factory.GetPrinter(output)
+	if err != nil {
+		return fmt.Errorf("unable to get printer: %w", err)
+	}
+
+	// print the result on the standard output
+	if err := p.Print(key, printer.Options{}, os.Stdout); err != nil {
+		return fmt.Errorf("unable to print result: %w", err)
+	}
+	return nil
+}

--- a/cmd/cycloid/apikey/delete.go
+++ b/cmd/cycloid/apikey/delete.go
@@ -1,0 +1,54 @@
+package apikey
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+)
+
+// NewDeleteCommand returns the cobra command holding
+// the delete API key subcommand
+func NewDeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "delete an API key",
+		Example: `
+	# delete the API key 'my-key' in the org my-org
+	cy api-key delete --org my-org --canonical my-key
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			org, err := cmd.Flags().GetString("org")
+			if err != nil {
+				return fmt.Errorf("unable to get org flag: %w", err)
+			}
+			output, err := cmd.Flags().GetString("output")
+			if err != nil {
+				return fmt.Errorf("unable to get output flag: %w", err)
+			}
+			canonical, err := cmd.Flags().GetString("canonical")
+			if err != nil {
+				return fmt.Errorf("unable to get canonical flag: %w", err)
+			}
+			return remove(org, canonical, output)
+		},
+	}
+
+	WithFlagCanonical(cmd)
+	cmd.MarkFlagRequired("canonical")
+	return cmd
+}
+
+// remove will send the DELETE request to the API in order to
+// delete a generated token
+func remove(org, canonical, output string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	if err := m.DeleteAPIKey(org, canonical); err != nil {
+		return fmt.Errorf("unable to delete API key: %w", err)
+	}
+	return nil
+}

--- a/cmd/cycloid/apikey/get.go
+++ b/cmd/cycloid/apikey/get.go
@@ -1,0 +1,69 @@
+package apikey
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/printer"
+	"github.com/cycloidio/cycloid-cli/printer/factory"
+)
+
+// NewGetCommand returns the cobra command holding
+// the get API key subcommand
+func NewGetCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "get API key",
+		Example: `
+	# get API key 'my-key' in the org my-org
+	cy api-key get --org my-org --canonical my-key
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			org, err := cmd.Flags().GetString("org")
+			if err != nil {
+				return fmt.Errorf("unable to get org flag: %w", err)
+			}
+			output, err := cmd.Flags().GetString("output")
+			if err != nil {
+				return fmt.Errorf("unable to get output flag: %w", err)
+			}
+			canonical, err := cmd.Flags().GetString("canonical")
+			if err != nil {
+				return fmt.Errorf("unable to get canonical flag: %w", err)
+			}
+			return get(org, canonical, output)
+		},
+	}
+
+	WithFlagCanonical(cmd)
+	cmd.MarkFlagRequired("canonical")
+	return cmd
+}
+
+// get will send the GET request to the API in order to
+// get the generated token
+func get(org, canonical, output string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	key, err := m.GetAPIKey(org, canonical)
+	if err != nil {
+		return fmt.Errorf("unable to get API key: %w", err)
+	}
+
+	// fetch the printer from the factory
+	p, err := factory.GetPrinter(output)
+	if err != nil {
+		return fmt.Errorf("unable to get printer: %w", err)
+	}
+
+	// print the result on the standard output
+	if err := p.Print(key, printer.Options{}, os.Stdout); err != nil {
+		return fmt.Errorf("unable to print result: %w", err)
+	}
+	return nil
+}

--- a/cmd/cycloid/apikey/list.go
+++ b/cmd/cycloid/apikey/list.go
@@ -1,0 +1,62 @@
+package apikey
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/printer"
+	"github.com/cycloidio/cycloid-cli/printer/factory"
+)
+
+// NewListCommand returns the cobra command holding
+// the list API key subcommand
+func NewListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "list API keys",
+		Example: `
+	# list API keys in the org my-org
+	cy api-key list --org my-org
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			org, err := cmd.Flags().GetString("org")
+			if err != nil {
+				return fmt.Errorf("unable to get org flag: %w", err)
+			}
+			output, err := cmd.Flags().GetString("output")
+			if err != nil {
+				return fmt.Errorf("unable to get output flag: %w", err)
+			}
+			return list(org, output)
+		},
+	}
+	return cmd
+}
+
+// list will send the GET request to the API in order to
+// list the generated tokens
+func list(org, output string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	keys, err := m.ListAPIKey(org)
+	if err != nil {
+		return fmt.Errorf("unable to list API keys: %w", err)
+	}
+
+	// fetch the printer from the factory
+	p, err := factory.GetPrinter(output)
+	if err != nil {
+		return fmt.Errorf("unable to get printer: %w", err)
+	}
+
+	// print the result on the standard output
+	if err := p.Print(keys, printer.Options{}, os.Stdout); err != nil {
+		return fmt.Errorf("unable to print result: %w", err)
+	}
+	return nil
+}

--- a/cmd/cycloid/common/helpers.go
+++ b/cmd/cycloid/common/helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 
 	"net/url"
 
@@ -124,4 +125,19 @@ func ClientCredentials(org *string) runtime.ClientAuthInfoWriter {
 		r.SetHeaderParam("Authorization", "Bearer "+token)
 		return nil
 	})
+}
+
+// GenerateCanonical will generate a canonical from the
+// name passed in input
+func GenerateCanonical(name string) string {
+	var (
+		extraspaces = regexp.MustCompile(`\s+`)
+		spaces      = regexp.MustCompile(`[^a-zA-z0-9_\-]`)
+		canonical   string
+	)
+
+	canonical = extraspaces.ReplaceAllString(name, " ")
+	canonical = spaces.ReplaceAllString(canonical, "-")
+
+	return strings.ToLower(canonical)
 }

--- a/cmd/cycloid/common/helpers_test.go
+++ b/cmd/cycloid/common/helpers_test.go
@@ -1,0 +1,41 @@
+package common_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+)
+
+func TestGenerateCanonical(t *testing.T) {
+	inputs := []struct {
+		Name      string
+		Canonical string
+	}{
+		{
+			Name:      "Test Project",
+			Canonical: "test-project",
+		},
+		{
+			Name:      "test project",
+			Canonical: "test-project",
+		},
+		{
+			Name:      "Test-Project",
+			Canonical: "test-project",
+		},
+		{
+			Name:      "test-project",
+			Canonical: "test-project",
+		},
+		{
+			Name:      "test          project",
+			Canonical: "test-project",
+		},
+	}
+
+	for _, input := range inputs {
+		assert.Equal(t, input.Canonical, common.GenerateCanonical(input.Name))
+	}
+}

--- a/cmd/cycloid/login/common.go
+++ b/cmd/cycloid/login/common.go
@@ -7,6 +7,7 @@ var (
 	email    string
 	password string
 	child    string
+	apiKey   string
 )
 
 func WithFlagOrg(cmd *cobra.Command) {
@@ -23,4 +24,8 @@ func WithFlagPassword(cmd *cobra.Command) {
 
 func WithFlagChild(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&child, "child", "", "child organization")
+}
+
+func WithFlagAPIKey(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&apiKey, "api-key", "", "API key")
 }

--- a/cmd/cycloid/middleware/api-key.go
+++ b/cmd/cycloid/middleware/api-key.go
@@ -56,3 +56,15 @@ func (m *middleware) GetAPIKey(org, canonical string) (*models.APIKey, error) {
 
 	return res.GetPayload().Data, nil
 }
+
+// DeleteAPIKey will request API to delete a specified generated API key
+func (m *middleware) DeleteAPIKey(org, canonical string) error {
+	params := organization_api_keys.NewDeleteAPIKeyParams()
+	params.SetOrganizationCanonical(org)
+	params.SetAPIKeyCanonical(canonical)
+
+	if _, err := m.api.OrganizationAPIKeys.DeleteAPIKey(params, common.ClientCredentials(&org)); err != nil {
+		return fmt.Errorf("unable to delete API key: %w", err)
+	}
+	return nil
+}

--- a/cmd/cycloid/middleware/api-key.go
+++ b/cmd/cycloid/middleware/api-key.go
@@ -29,3 +29,16 @@ func (m *middleware) CreateAPIKey(org, name, canonical, description string, role
 
 	return res.GetPayload().Data, nil
 }
+
+// ListAPIKey will request API to list generated API keys
+func (m *middleware) ListAPIKey(org string) ([]*models.APIKey, error) {
+	params := organization_api_keys.NewGetAPIKeysParams()
+	params.SetOrganizationCanonical(org)
+
+	res, err := m.api.OrganizationAPIKeys.GetAPIKeys(params, common.ClientCredentials(&org))
+	if err != nil {
+		return nil, fmt.Errorf("unable to list API keys: %w", err)
+	}
+
+	return res.GetPayload().Data, nil
+}

--- a/cmd/cycloid/middleware/api-key.go
+++ b/cmd/cycloid/middleware/api-key.go
@@ -42,3 +42,17 @@ func (m *middleware) ListAPIKey(org string) ([]*models.APIKey, error) {
 
 	return res.GetPayload().Data, nil
 }
+
+// GetAPIKey will request API to get a specified generated API key by its canonical
+func (m *middleware) GetAPIKey(org, canonical string) (*models.APIKey, error) {
+	params := organization_api_keys.NewGetAPIKeyParams()
+	params.SetOrganizationCanonical(org)
+	params.SetAPIKeyCanonical(canonical)
+
+	res, err := m.api.OrganizationAPIKeys.GetAPIKey(params, common.ClientCredentials(&org))
+	if err != nil {
+		return nil, fmt.Errorf("unable to get API key: %w", err)
+	}
+
+	return res.GetPayload().Data, nil
+}

--- a/cmd/cycloid/middleware/api-key.go
+++ b/cmd/cycloid/middleware/api-key.go
@@ -1,0 +1,31 @@
+package middleware
+
+import (
+	"fmt"
+
+	"github.com/cycloidio/cycloid-cli/client/client/organization_api_keys"
+	"github.com/cycloidio/cycloid-cli/client/models"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+)
+
+// CreateAPIKey will request API to generate and return an API key
+func (m *middleware) CreateAPIKey(org, name, canonical, description string, roleID uint32) (*models.APIKey, error) {
+	params := organization_api_keys.NewCreateAPIKeyParams()
+
+	body := &models.NewAPIKey{
+		Canonical:   &canonical,
+		Description: description,
+		Name:        &name,
+		RoleID:      &roleID,
+	}
+
+	params.SetBody(body)
+	params.SetOrganizationCanonical(org)
+
+	res, err := m.api.OrganizationAPIKeys.CreateAPIKey(params, common.ClientCredentials(&org))
+	if err != nil {
+		return nil, fmt.Errorf("unable to create API key: %w", err)
+	}
+
+	return res.GetPayload().Data, nil
+}

--- a/cmd/cycloid/middleware/login.go
+++ b/cmd/cycloid/middleware/login.go
@@ -33,7 +33,7 @@ func (m *middleware) Login(email, password string) (*models.UserSession, error) 
 	return res.GetPayload().Data, nil
 }
 
-func (m *middleware) LoginOrg(org, child, username, password string) (*models.UserSession, error) {
+func (m *middleware) LoginOrg(org, child string) (*models.UserSession, error) {
 
 	params := user.NewRefreshTokenParams()
 	params.SetOrganizationCanonical(&org)

--- a/cmd/cycloid/middleware/middleware.go
+++ b/cmd/cycloid/middleware/middleware.go
@@ -89,6 +89,9 @@ type Middleware interface {
 
 	// ListAPIKey will request API to list generated API keys
 	ListAPIKey(org string) ([]*models.APIKey, error)
+
+	// GetAPIKey will request API to get a specified generated API key by its canonical
+	GetAPIKey(org, canonical string) (*models.APIKey, error)
 }
 
 type middleware struct {

--- a/cmd/cycloid/middleware/middleware.go
+++ b/cmd/cycloid/middleware/middleware.go
@@ -86,6 +86,9 @@ type Middleware interface {
 	// API keys method
 	// CreateAPIKey will request API to generate and return an API key
 	CreateAPIKey(org, name, canonical, description string, roleID uint32) (*models.APIKey, error)
+
+	// ListAPIKey will request API to list generated API keys
+	ListAPIKey(org string) ([]*models.APIKey, error)
 }
 
 type middleware struct {

--- a/cmd/cycloid/middleware/middleware.go
+++ b/cmd/cycloid/middleware/middleware.go
@@ -92,6 +92,9 @@ type Middleware interface {
 
 	// GetAPIKey will request API to get a specified generated API key by its canonical
 	GetAPIKey(org, canonical string) (*models.APIKey, error)
+
+	// DeleteAPIKey will request API to delete a specified generated API key
+	DeleteAPIKey(org, canonical string) error
 }
 
 type middleware struct {

--- a/cmd/cycloid/middleware/middleware.go
+++ b/cmd/cycloid/middleware/middleware.go
@@ -42,7 +42,7 @@ type Middleware interface {
 	Login(email, password string) (*models.UserSession, error)
 
 	// LoginOrg is the used to log the user into a Cycloid organization
-	LoginOrg(org, child, email, password string) (*models.UserSession, error)
+	LoginOrg(org, child string) (*models.UserSession, error)
 
 	DeleteMember(org string, name string) error
 	GetMember(org string, name string) (*models.MemberOrg, error)
@@ -82,6 +82,10 @@ type Middleware interface {
 
 	GetStack(org, ref string) (*models.ServiceCatalog, error)
 	ListStacks(org string) ([]*models.ServiceCatalog, error)
+
+	// API keys method
+	// CreateAPIKey will request API to generate and return an API key
+	CreateAPIKey(org, name, canonical, description string, roleID uint32) (*models.APIKey, error)
 }
 
 type middleware struct {

--- a/cmd/cycloid/middleware/organization.go
+++ b/cmd/cycloid/middleware/organization.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	strfmt "github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
-	"regexp"
 
 	"github.com/cycloidio/cycloid-cli/client/client/organization_workers"
 	"github.com/cycloidio/cycloid-cli/client/client/organizations"
@@ -16,8 +15,7 @@ func (m *middleware) CreateOrganization(name string, canonical string) (*models.
 	params := organizations.NewCreateOrgParams()
 
 	if canonical == "" {
-		re := regexp.MustCompile(`[^a-zA-z0-9_\-]`)
-		canonical = re.ReplaceAllString(name, "-")
+		canonical = common.GenerateCanonical(name)
 	}
 
 	body := &models.NewOrganization{

--- a/config/config.go
+++ b/config/config.go
@@ -37,13 +37,19 @@ type Organization struct {
 func ReadConfig() (*Config, error) {
 	configFilePath, err := xdg.ConfigFile(fmt.Sprintf("%s/%s", appName, path))
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to find XDG config path")
+		return &Config{
+			Token:         "",
+			Organizations: make(map[string]Organization),
+		}, errors.Wrap(err, "unable to find XDG config path")
 	}
 	content, err := ioutil.ReadFile(configFilePath)
 	if err != nil {
 		// we return an empty Config in case it's the first time we try to access
 		// the config and it does not exist yet
-		return &Config{}, errors.Wrap(err, "unable to read config from file")
+		return &Config{
+			Token:         "",
+			Organizations: make(map[string]Organization),
+		}, errors.Wrap(err, "unable to read config from file")
 	}
 	var c Config
 	if err := yaml.Unmarshal(content, &c); err != nil {


### PR DESCRIPTION
Implement the API keys endpoint:

* `create` to create an API key
* `delete` to delete an API key
* `list` to list API keys
* `get` to fetch one API key

:warning: Once generated, the token won't be available anymore.

Exemple:

```shell
$ cy ak --org toto list
CANONICAL       DESCRIPTION             ID      LASTSEVEN       NAME            TOKEN
test-cli-bis    token to test CLI       4       an1TvfY         test-cli-bis
```

Modify the login method method in order to accept `--api-key` instead of `--email / --password`. (also work by exporting TOKEN env variable, as usual)