### PR TITLE
cmd/login: fix regression issue on the user login

### DIFF
--- a/cmd/cycloid/login/login.go
+++ b/cmd/cycloid/login/login.go
@@ -58,12 +58,11 @@ func NewCommands() *cobra.Command {
 		},
 	}
 
-	common.RequiredPersistentFlag(common.WithFlagOrg, cmd)
-
 	WithFlagEmail(cmd)
 	WithFlagPassword(cmd)
 	WithFlagChild(cmd)
 	WithFlagAPIKey(cmd)
+	WithFlagOrg(cmd)
 
 	cmd.AddCommand(
 		NewListCommand(),


### PR DESCRIPTION
org was required but it should not in a user login context