### PR TITLE
forms: convert models.FormsFile to fit JSON standards

### DIFF
--- a/cmd/cycloid/middleware/utils.go
+++ b/cmd/cycloid/middleware/utils.go
@@ -1,0 +1,36 @@
+package middleware
+
+import "fmt"
+
+func convertInterfaceArray(ia []interface{}) []interface{} {
+	res := make([]interface{}, len(ia))
+	for i, v := range ia {
+		res[i] = ConvertMapInterfaceToMapString(v)
+	}
+	return res
+}
+
+func convertInterfaceMap(mii map[interface{}]interface{}) map[string]interface{} {
+	ms := make(map[string]interface{})
+	for k, v := range mii {
+		ms[fmt.Sprintf("%v", k)] = ConvertMapInterfaceToMapString(v)
+	}
+	return ms
+}
+
+// ConvertMapInterfaceToMapString is a method necessary to have JSON marshal
+// working properly JSON doesn't know how to handle map[interface{}]interface{}
+// so instead of keeping it, we are conveting it to map[string]interface{}.
+// If the interface p isn't a map then we simply return it as it is.
+func ConvertMapInterfaceToMapString(p interface{}) interface{} {
+	switch v := p.(type) {
+	case []interface{}:
+		return convertInterfaceArray(v)
+	case map[interface{}]interface{}:
+		return convertInterfaceMap(v)
+	case string:
+		return v
+	default:
+		return v
+	}
+}


### PR DESCRIPTION
JSON doesn't handle map[interface{}]interface{} whereas YAML can, so to
be able to use the endpoint properly we need to convert those prior to
sending them.

This fixes the error when using the `validate-form` cmd:
`Error: unable validate form: json: unsupported type: map[interface {}]interface {}`

However the output of the Body is printed right away, which is confusing with that endpoint as it returns:

```
(*organization_forms.ValidateFormsFileOK)(0xc00021e2d0)([POST /organizations/{organization_canonical}/forms/validate][200] validateFormsFileOK  &{Data:0xc00046a640})

(*organization_forms.ValidateFormsFileOKBody)(0xc0000c8870)({
 Data: (*models.FormsValidationResult)(0xc000559360)({
  Errors: ([]string) {
  }
 })
})
```

So the basic output is:
```
ERRORS
```
While the call succeeded.