### PR TITLE
wrapper: Add more retry and wait for network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## [v1.0.83] _2021-10-26_
 - **ADDED**
   - Adding new pipeline synced command
-    ([PR #105](https://github.com/cycloidio/cycloid-cli/pull/111))
+    ([PR #111](https://github.com/cycloidio/cycloid-cli/pull/111))
+  - CY wrapper, add more retry on and wait for network
+    ([PR #110](https://github.com/cycloidio/cycloid-cli/pull/110))
 
 ## [v1.0.82] _2021-10-04_
 - **ADDED**


### PR DESCRIPTION
From time to time in some pipeline there ie a random network issue.
To provide a more robust concourse resource (which is based on CLI wrapper),
we added few network checks and some more retry as workaround to ensure to wait
network in case of failure.