### PR TITLE
cy-wrapper: Now use Cycloid URL instead of Github URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 - **CHANGED**
   - Update client to version v1.0.88
   ([PR #125](https://github.com/cycloidio/cycloid-cli/pull/125))
+  - cy-wrapper: Now use Cycloid URL instead of Github to avoid API request limits
+  ([PR #126](https://github.com/cycloidio/cycloid-cli/pull/126))
 
 ## [v1.0.86] _2022-01-04_
 - **CHANGED**

--- a/scripts/cy-wrapper.sh
+++ b/scripts/cy-wrapper.sh
@@ -62,7 +62,7 @@ format_version () {
 find_version_below () {
   api_version=$(format_version $1)
 
-  for cli_release in $(curl --fail --retry-all-errors --retry-delay 2 --retry 5 --silent "https://api.github.com/repos/cycloidio/cycloid-cli/releases" | jq -r '.[] | .name'); do
+  for cli_release in $(curl --fail --retry-all-errors --retry-delay 2 --retry 5 --silent "https://cli-release.owl.cycloid.io/releases" | jq -r '.[] | .name'); do
     cli_version=$(format_version $cli_release)
     # Ignoring the dev release from github
     if [[ "$cli_version" == "0.0-dev" ]]; then
@@ -155,7 +155,7 @@ CY_API_URL=${CY_API_URL%/}
 
 # Wait for network access. This ensure in case of usage in a pipeline to ensure and wait in case network is not started.
 if [[ "$CY_WAIT_NETWORK" == "true" ]]; then
-    timeout 120 bash -c 'while [[ "$(curl --insecure -s -o /dev/null -w ''%{http_code}'' https://api.github.com/repos/cycloidio/cycloid-cli/releases)" != "200" ]]; do sleep 3; done'
+    timeout 120 bash -c 'while [[ "$(curl --insecure -s -o /dev/null -w ''%{http_code}'' https://cli-release.owl.cycloid.io/releases)" != "200" ]]; do sleep 3; done'
 fi
 
 # Get Cycloid API version


### PR DESCRIPTION
As wrapper is used accross several pipelines, intensive usage raise Github API request limits.
To avoid this kind of issue we provided a dedicated Cycloid url to obtain the list of released
instead of using Github API.