### PR TITLE
client: update Action references from new swagger spec

### DIFF
--- a/changelog/unreleased/Other-CHANGED-20220712-155743.yaml
+++ b/changelog/unreleased/Other-CHANGED-20220712-155743.yaml
@@ -1,0 +1,7 @@
+component: CLI
+kind: CHANGED
+body: 'client: update Action references from new swagger spec'
+time: 2022-10-07T13:00:05.027432241Z
+custom:
+  PR: "155"
+  DETAILS: "client: update Action references from new swagger spec"

--- a/cmd/cycloid/middleware/organization.go
+++ b/cmd/cycloid/middleware/organization.go
@@ -4,8 +4,8 @@ import (
 	strfmt "github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 
-	"github.com/cycloidio/cycloid-cli/client/client/organization_workers"
 	"github.com/cycloidio/cycloid-cli/client/client/organization_children"
+	"github.com/cycloidio/cycloid-cli/client/client/organization_workers"
 	"github.com/cycloidio/cycloid-cli/client/client/organizations"
 	"github.com/cycloidio/cycloid-cli/client/models"
 	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"


### PR DESCRIPTION
This is a placeholder PR to update the action names, as part of a new version of the Swagger spec.

Closes: https://github.com/cycloidio/cycloid-cli/issues/155