### PR TITLE
cmd/cycloid/common: Added variadic configuration to the API

### DIFF
--- a/cmd/cycloid/middleware/api-key.go
+++ b/cmd/cycloid/middleware/api-key.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cycloidio/cycloid-cli/client/client/organization_api_keys"
 	"github.com/cycloidio/cycloid-cli/client/models"
-	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
 )
 
 // ListAPIKey will request API to list generated API keys
@@ -13,7 +12,7 @@ func (m *middleware) ListAPIKey(org string) ([]*models.APIKey, error) {
 	params := organization_api_keys.NewGetAPIKeysParams()
 	params.SetOrganizationCanonical(org)
 
-	res, err := m.api.OrganizationAPIKeys.GetAPIKeys(params, common.ClientCredentials(&org))
+	res, err := m.api.OrganizationAPIKeys.GetAPIKeys(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, fmt.Errorf("unable to list API keys: %w", NewApiError(err))
 	}
@@ -27,7 +26,7 @@ func (m *middleware) GetAPIKey(org, canonical string) (*models.APIKey, error) {
 	params.SetOrganizationCanonical(org)
 	params.SetAPIKeyCanonical(canonical)
 
-	res, err := m.api.OrganizationAPIKeys.GetAPIKey(params, common.ClientCredentials(&org))
+	res, err := m.api.OrganizationAPIKeys.GetAPIKey(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, fmt.Errorf("unable to get API key: %w", NewApiError(err))
 	}
@@ -41,7 +40,7 @@ func (m *middleware) DeleteAPIKey(org, canonical string) error {
 	params.SetOrganizationCanonical(org)
 	params.SetAPIKeyCanonical(canonical)
 
-	if _, err := m.api.OrganizationAPIKeys.DeleteAPIKey(params, common.ClientCredentials(&org)); err != nil {
+	if _, err := m.api.OrganizationAPIKeys.DeleteAPIKey(params, m.api.Credentials(&org)); err != nil {
 		return fmt.Errorf("unable to delete API key: %w", NewApiError(err))
 	}
 	return nil

--- a/cmd/cycloid/middleware/catalog-repositories.go
+++ b/cmd/cycloid/middleware/catalog-repositories.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"github.com/cycloidio/cycloid-cli/client/client/organization_service_catalog_sources"
 	"github.com/cycloidio/cycloid-cli/client/models"
-	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
 	strfmt "github.com/go-openapi/strfmt"
 )
 
@@ -12,7 +11,7 @@ func (m *middleware) ListCatalogRepositories(org string) ([]*models.ServiceCatal
 	params := organization_service_catalog_sources.NewGetServiceCatalogSourcesParams()
 	params.SetOrganizationCanonical(org)
 
-	resp, err := m.api.OrganizationServiceCatalogSources.GetServiceCatalogSources(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationServiceCatalogSources.GetServiceCatalogSources(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -34,7 +33,7 @@ func (m *middleware) GetCatalogRepository(org, catalogRepo string) (*models.Serv
 	params.SetOrganizationCanonical(org)
 	params.SetServiceCatalogSourceCanonical(catalogRepo)
 
-	resp, err := m.api.OrganizationServiceCatalogSources.GetServiceCatalogSource(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationServiceCatalogSources.GetServiceCatalogSource(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -55,7 +54,7 @@ func (m *middleware) DeleteCatalogRepository(org, catalogRepo string) error {
 	params.SetOrganizationCanonical(org)
 	params.SetServiceCatalogSourceCanonical(catalogRepo)
 
-	_, err := m.api.OrganizationServiceCatalogSources.DeleteServiceCatalogSource(params, common.ClientCredentials(&org))
+	_, err := m.api.OrganizationServiceCatalogSources.DeleteServiceCatalogSource(params, m.api.Credentials(&org))
 	if err != nil {
 		return NewApiError(err)
 	}
@@ -90,7 +89,7 @@ func (m *middleware) CreateCatalogRepository(org, name, url, branch, cred string
 		return nil, err
 	}
 
-	resp, err := m.api.OrganizationServiceCatalogSources.CreateServiceCatalogSource(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationServiceCatalogSources.CreateServiceCatalogSource(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -126,7 +125,7 @@ func (m *middleware) UpdateCatalogRepository(org, catalogRepo string, name, url,
 		return nil, err
 	}
 
-	resp, err := m.api.OrganizationServiceCatalogSources.UpdateServiceCatalogSource(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationServiceCatalogSources.UpdateServiceCatalogSource(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -148,7 +147,7 @@ func (m *middleware) RefreshCatalogRepository(org, catalogRepo string) (*models.
 	params.SetOrganizationCanonical(org)
 	params.SetServiceCatalogSourceCanonical(catalogRepo)
 
-	resp, err := m.api.OrganizationServiceCatalogSources.RefreshServiceCatalogSource(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationServiceCatalogSources.RefreshServiceCatalogSource(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}

--- a/cmd/cycloid/middleware/config-repositories.go
+++ b/cmd/cycloid/middleware/config-repositories.go
@@ -54,7 +54,7 @@ func (m *middleware) PushConfig(org string, project string, env string, configs 
 	}
 
 	params.SetBody(body)
-	_, err = m.api.OrganizationConfigRepositories.CreateConfigRepositoryConfig(params, common.ClientCredentials(&org))
+	_, err = m.api.OrganizationConfigRepositories.CreateConfigRepositoryConfig(params, m.api.Credentials(&org))
 	if err != nil {
 		return NewApiError(err)
 	}
@@ -67,7 +67,7 @@ func (m *middleware) ListConfigRepositories(org string) ([]*models.ConfigReposit
 	params := organization_config_repositories.NewListConfigRepositoriesParams()
 	params.SetOrganizationCanonical(org)
 
-	resp, err := m.api.OrganizationConfigRepositories.ListConfigRepositories(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationConfigRepositories.ListConfigRepositories(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -89,7 +89,7 @@ func (m *middleware) GetConfigRepository(org, configRepo string) (*models.Config
 	params.SetOrganizationCanonical(org)
 	params.SetConfigRepositoryCanonical(configRepo)
 
-	resp, err := m.api.OrganizationConfigRepositories.GetConfigRepository(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationConfigRepositories.GetConfigRepository(params, m.api.Credentials(&org))
 
 	if err != nil {
 		return nil, NewApiError(err)
@@ -111,7 +111,7 @@ func (m *middleware) DeleteConfigRepository(org, configRepo string) error {
 	params.SetOrganizationCanonical(org)
 	params.SetConfigRepositoryCanonical(configRepo)
 
-	_, err := m.api.OrganizationConfigRepositories.DeleteConfigRepository(params, common.ClientCredentials(&org))
+	_, err := m.api.OrganizationConfigRepositories.DeleteConfigRepository(params, m.api.Credentials(&org))
 	if err != nil {
 		return NewApiError(err)
 	}
@@ -137,7 +137,7 @@ func (m *middleware) CreateConfigRepository(org, name, url, branch, cred string,
 		return nil, err
 	}
 
-	resp, err := m.api.OrganizationConfigRepositories.CreateConfigRepository(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationConfigRepositories.CreateConfigRepository(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -173,7 +173,7 @@ func (m *middleware) UpdateConfigRepository(org, configRepo, cred, name, url, br
 		return nil, err
 	}
 
-	resp, err := m.api.OrganizationConfigRepositories.UpdateConfigRepository(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationConfigRepositories.UpdateConfigRepository(params, m.api.Credentials(&org))
 
 	if err != nil {
 		return nil, NewApiError(err)

--- a/cmd/cycloid/middleware/creds.go
+++ b/cmd/cycloid/middleware/creds.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/cycloidio/cycloid-cli/client/client/organization_credentials"
 	"github.com/cycloidio/cycloid-cli/client/models"
-	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
 	strfmt "github.com/go-openapi/strfmt"
 )
 
@@ -36,7 +35,7 @@ func (m *middleware) CreateCredential(org, name, cType string, rawCred *models.C
 		return err
 	}
 
-	_, err = m.api.OrganizationCredentials.CreateCredential(params, common.ClientCredentials(&org))
+	_, err = m.api.OrganizationCredentials.CreateCredential(params, m.api.Credentials(&org))
 	if err != nil {
 		return NewApiError(err)
 	}
@@ -50,7 +49,7 @@ func (m *middleware) GetCredential(org, cred string) (*models.Credential, error)
 	params.SetOrganizationCanonical(org)
 	params.SetCredentialCanonical(cred)
 
-	resp, err := m.api.OrganizationCredentials.GetCredential(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationCredentials.GetCredential(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -67,7 +66,7 @@ func (m *middleware) DeleteCredential(org, cred string) error {
 	params.SetOrganizationCanonical(org)
 	params.SetCredentialCanonical(cred)
 
-	_, err := m.api.OrganizationCredentials.DeleteCredential(params, common.ClientCredentials(&org))
+	_, err := m.api.OrganizationCredentials.DeleteCredential(params, m.api.Credentials(&org))
 	if err != nil {
 		return NewApiError(err)
 	}
@@ -84,7 +83,7 @@ func (m *middleware) ListCredentials(org, cType string) ([]*models.CredentialSim
 		params.SetCredentialType(&cType)
 	}
 
-	resp, err := m.api.OrganizationCredentials.ListCredentials(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationCredentials.ListCredentials(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}

--- a/cmd/cycloid/middleware/event.go
+++ b/cmd/cycloid/middleware/event.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"github.com/cycloidio/cycloid-cli/client/client/organizations"
 	"github.com/cycloidio/cycloid-cli/client/models"
-	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
 	strfmt "github.com/go-openapi/strfmt"
 )
 
@@ -45,7 +44,7 @@ func (m *middleware) SendEvent(org, eventType, title, message, severity string, 
 		return err
 	}
 
-	_, err = m.api.Organizations.SendEvent(params, common.ClientCredentials(&org))
+	_, err = m.api.Organizations.SendEvent(params, m.api.Credentials(&org))
 	if err != nil {
 		return NewApiError(err)
 	}

--- a/cmd/cycloid/middleware/external-backends.go
+++ b/cmd/cycloid/middleware/external-backends.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"github.com/cycloidio/cycloid-cli/client/client/organization_external_backends"
 	"github.com/cycloidio/cycloid-cli/client/models"
-	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
 	strfmt "github.com/go-openapi/strfmt"
 )
 
@@ -12,7 +11,7 @@ func (m *middleware) ListExternalBackends(org string) ([]*models.ExternalBackend
 	params := organization_external_backends.NewGetExternalBackendsParams()
 	params.SetOrganizationCanonical(org)
 
-	resp, err := m.api.OrganizationExternalBackends.GetExternalBackends(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationExternalBackends.GetExternalBackends(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -34,7 +33,7 @@ func (m *middleware) DeleteExternalBackend(org string, externalBackend uint32) e
 	params.SetOrganizationCanonical(org)
 	params.SetExternalBackendID(externalBackend)
 
-	_, err := m.api.OrganizationExternalBackends.DeleteExternalBackend(params, common.ClientCredentials(&org))
+	_, err := m.api.OrganizationExternalBackends.DeleteExternalBackend(params, m.api.Credentials(&org))
 	if err != nil {
 		return NewApiError(err)
 	}
@@ -79,7 +78,7 @@ func (m *middleware) CreateExternalBackends(org, project, env, purpose, cred str
 		return nil, err
 	}
 
-	resp, err := m.api.OrganizationExternalBackends.CreateExternalBackend(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationExternalBackends.CreateExternalBackend(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}

--- a/cmd/cycloid/middleware/infra-policies.go
+++ b/cmd/cycloid/middleware/infra-policies.go
@@ -23,7 +23,7 @@ func (m *middleware) ValidateInfraPolicies(org, project, env string, plan []byte
 		Tfplan: &tfplan,
 	})
 
-	resp, err := m.api.OrganizationInfrastructurePolicies.ValidateProjectInfraPolicies(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationInfrastructurePolicies.ValidateProjectInfraPolicies(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -70,7 +70,7 @@ func (m *middleware) CreateInfraPolicy(org, policyFile, policyCanonical, descrip
 	}
 
 	params.SetBody(body)
-	resp, err := m.api.OrganizationInfrastructurePolicies.CreateInfraPolicy(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationInfrastructurePolicies.CreateInfraPolicy(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -91,7 +91,7 @@ func (m *middleware) DeleteInfraPolicy(org, policyCannonical string) error {
 	params.SetOrganizationCanonical(org)
 	params.SetInfraPolicyCanonical(policyCannonical)
 
-	_, err := m.api.OrganizationInfrastructurePolicies.DeleteInfraPolicy(params, common.ClientCredentials(&org))
+	_, err := m.api.OrganizationInfrastructurePolicies.DeleteInfraPolicy(params, m.api.Credentials(&org))
 	if err != nil {
 		return NewApiError(err)
 	}
@@ -104,7 +104,7 @@ func (m *middleware) ListInfraPolicies(org string) ([]*models.InfraPolicy, error
 	params := organization_infrastructure_policies.NewGetInfraPoliciesParams()
 	params.SetOrganizationCanonical(org)
 
-	resp, err := m.api.OrganizationInfrastructurePolicies.GetInfraPolicies(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationInfrastructurePolicies.GetInfraPolicies(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (m *middleware) GetInfraPolicy(org, infraPolicy string) (*models.InfraPolic
 	params.SetOrganizationCanonical(org)
 	params.SetInfraPolicyCanonical(infraPolicy)
 
-	resp, err := m.api.OrganizationInfrastructurePolicies.GetInfraPolicy(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationInfrastructurePolicies.GetInfraPolicy(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -172,7 +172,7 @@ func (m *middleware) UpdateInfraPolicy(org, infraPolicy, policyFile, description
 	}
 
 	params.SetBody(body)
-	resp, err := m.api.OrganizationInfrastructurePolicies.UpdateInfraPolicy(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationInfrastructurePolicies.UpdateInfraPolicy(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}

--- a/cmd/cycloid/middleware/kpi.go
+++ b/cmd/cycloid/middleware/kpi.go
@@ -52,7 +52,7 @@ func (m *middleware) CreateKpi(name, kpiType, widget, org, project, job, env, co
 	}
 
 	params.SetBody(body)
-	resp, err := m.api.OrganizationKpis.CreateKpi(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationKpis.CreateKpi(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -73,7 +73,7 @@ func (m *middleware) ListKpi(org, project, env string) ([]*models.KPI, error) {
 		params.SetEnvironment(&env)
 	}
 
-	resp, err := m.api.OrganizationKpis.GetKpis(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationKpis.GetKpis(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -89,7 +89,7 @@ func (m *middleware) DeleteKpi(org, kpi string) error {
 	params.SetOrganizationCanonical(org)
 	params.SetKpiCanonical(kpi)
 
-	_, err := m.api.OrganizationKpis.DeleteKpi(params, common.ClientCredentials(&org))
+	_, err := m.api.OrganizationKpis.DeleteKpi(params, m.api.Credentials(&org))
 	if err != nil {
 		return NewApiError(err)
 	}

--- a/cmd/cycloid/middleware/members.go
+++ b/cmd/cycloid/middleware/members.go
@@ -8,14 +8,13 @@ import (
 	"github.com/cycloidio/cycloid-cli/client/client/organization_invitations"
 	"github.com/cycloidio/cycloid-cli/client/client/organization_members"
 	"github.com/cycloidio/cycloid-cli/client/models"
-	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
 )
 
 func (m *middleware) ListMembers(org string) ([]*models.MemberOrg, error) {
 	params := organization_members.NewGetOrgMembersParams()
 	params.SetOrganizationCanonical(org)
 
-	resp, err := m.api.OrganizationMembers.GetOrgMembers(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationMembers.GetOrgMembers(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -36,7 +35,7 @@ func (m *middleware) ListInvites(org string) ([]*models.Invitation, error) {
 	params := organization_invitations.NewGetInvitationsParams()
 	params.SetOrganizationCanonical(org)
 
-	resp, err := m.api.OrganizationInvitations.GetInvitations(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationInvitations.GetInvitations(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -53,7 +52,7 @@ func (m *middleware) GetMember(org string, name string) (*models.MemberOrg, erro
 	params.SetOrganizationCanonical(org)
 	params.SetUsername(name)
 
-	resp, err := m.api.OrganizationMembers.GetOrgMember(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationMembers.GetOrgMember(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -75,7 +74,7 @@ func (m *middleware) DeleteMember(org string, name string) error {
 	params.SetOrganizationCanonical(org)
 	params.SetUsername(name)
 
-	_, err := m.api.OrganizationMembers.RemoveOrgMember(params, common.ClientCredentials(&org))
+	_, err := m.api.OrganizationMembers.RemoveOrgMember(params, m.api.Credentials(&org))
 	if err != nil {
 		return err
 	}
@@ -99,7 +98,7 @@ func (m *middleware) UpdateMembers(org, name, role string) (*models.MemberOrg, e
 		return nil, err
 	}
 
-	resp, err := m.api.OrganizationMembers.UpdateOrgMember(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationMembers.UpdateOrgMember(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -133,7 +132,7 @@ func (m *middleware) InviteMember(org, email, role string) error {
 		return err
 	}
 
-	_, err = m.api.OrganizationMembers.InviteUserToOrgMember(params, common.ClientCredentials(&org))
+	_, err = m.api.OrganizationMembers.InviteUserToOrgMember(params, m.api.Credentials(&org))
 	if err != nil {
 		return NewApiError(err)
 	}
@@ -151,7 +150,7 @@ func (m *middleware) DeleteInvite(org string, invite string) error {
 	}
 	params.SetInvitationID(uint32(i64))
 
-	_, err = m.api.OrganizationInvitations.DeleteInvitation(params, common.ClientCredentials(&org))
+	_, err = m.api.OrganizationInvitations.DeleteInvitation(params, m.api.Credentials(&org))
 	if err != nil {
 		return NewApiError(err)
 	}

--- a/cmd/cycloid/middleware/middleware.go
+++ b/cmd/cycloid/middleware/middleware.go
@@ -1,8 +1,8 @@
 package middleware
 
 import (
-	"github.com/cycloidio/cycloid-cli/client/client"
 	"github.com/cycloidio/cycloid-cli/client/models"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
 	strfmt "github.com/go-openapi/strfmt"
 )
 
@@ -112,9 +112,9 @@ type Middleware interface {
 }
 
 type middleware struct {
-	api *client.APIClient
+	api *common.APIClient
 }
 
-func NewMiddleware(api *client.APIClient) Middleware {
+func NewMiddleware(api *common.APIClient) Middleware {
 	return &middleware{api: api}
 }

--- a/cmd/cycloid/middleware/organization.go
+++ b/cmd/cycloid/middleware/organization.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"github.com/davecgh/go-spew/spew"
 	strfmt "github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 
@@ -9,7 +8,6 @@ import (
 	"github.com/cycloidio/cycloid-cli/client/client/organization_workers"
 	"github.com/cycloidio/cycloid-cli/client/client/organizations"
 	"github.com/cycloidio/cycloid-cli/client/models"
-	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
 )
 
 func (m *middleware) CreateOrganization(name string) (*models.Organization, error) {
@@ -26,7 +24,7 @@ func (m *middleware) CreateOrganization(name string) (*models.Organization, erro
 		return nil, errors.Wrap(err, "unable to validate request body")
 	}
 
-	resp, err := m.api.Organizations.CreateOrg(params, common.ClientCredentials(nil))
+	resp, err := m.api.Organizations.CreateOrg(params, m.api.Credentials(nil))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -42,7 +40,7 @@ func (m *middleware) GetOrganization(org string) (*models.Organization, error) {
 	params := organizations.NewGetOrgParams()
 	params.SetOrganizationCanonical(org)
 
-	resp, err := m.api.Organizations.GetOrg(params, common.ClientCredentials(&org))
+	resp, err := m.api.Organizations.GetOrg(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -62,7 +60,7 @@ func (m *middleware) ListOrganizationWorkers(org string) ([]*models.Worker, erro
 	params := organization_workers.NewGetWorkersParams()
 	params.SetOrganizationCanonical(org)
 
-	resp, err := m.api.OrganizationWorkers.GetWorkers(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationWorkers.GetWorkers(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -81,7 +79,7 @@ func (m *middleware) ListOrganizations() ([]*models.Organization, error) {
 
 	params := organizations.NewGetOrgsParams()
 
-	resp, err := m.api.Organizations.GetOrgs(params, common.ClientCredentials(nil))
+	resp, err := m.api.Organizations.GetOrgs(params, m.api.Credentials(nil))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -103,7 +101,7 @@ func (m *middleware) ListOrganizationChildrens(org string) ([]*models.Organizati
 	params.SetOrderBy(&orderBy)
 	params.SetOrganizationCanonical(org)
 
-	resp, err := m.api.OrganizationChildren.GetChildren(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationChildren.GetChildren(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -130,8 +128,7 @@ func (m *middleware) CreateOrganizationChild(org, porg string) (*models.Organiza
 		return nil, errors.Wrap(err, "unable to validate request body")
 	}
 
-	resp, err := m.api.OrganizationChildren.CreateChild(params, common.ClientCredentials(&porg))
-	spew.Dump(err)
+	resp, err := m.api.OrganizationChildren.CreateChild(params, m.api.Credentials(&porg))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -146,7 +143,7 @@ func (m *middleware) DeleteOrganization(org string) error {
 	params := organizations.NewDeleteOrgParams()
 	params.SetOrganizationCanonical(org)
 
-	_, err := m.api.Organizations.DeleteOrg(params, common.ClientCredentials(&org))
+	_, err := m.api.Organizations.DeleteOrg(params, m.api.Credentials(&org))
 	if err != nil {
 		return NewApiError(err)
 	}

--- a/cmd/cycloid/middleware/pipeline.go
+++ b/cmd/cycloid/middleware/pipeline.go
@@ -18,7 +18,7 @@ func (m *middleware) PausePipeline(org, project, env string) error {
 	params.SetProjectCanonical(project)
 	params.SetInpathPipelineName(pipelineName)
 
-	_, err := m.api.OrganizationPipelines.PausePipeline(params, common.ClientCredentials(&org))
+	_, err := m.api.OrganizationPipelines.PausePipeline(params, m.api.Credentials(&org))
 	if err != nil {
 		return NewApiError(err)
 	}
@@ -37,7 +37,7 @@ func (m *middleware) ClearTaskCachePipeline(org, project, env, job, task string)
 	params.SetJobName(job)
 	params.SetStepName(task)
 
-	_, err := m.api.OrganizationPipelinesJobs.ClearTaskCache(params, common.ClientCredentials(&org))
+	_, err := m.api.OrganizationPipelinesJobs.ClearTaskCache(params, m.api.Credentials(&org))
 	if err != nil {
 		return NewApiError(err)
 	}
@@ -54,7 +54,7 @@ func (m *middleware) UnpausePipeline(org, project, env string) error {
 	params.SetProjectCanonical(project)
 	params.SetInpathPipelineName(pipelineName)
 
-	_, err := m.api.OrganizationPipelines.UnpausePipeline(params, common.ClientCredentials(&org))
+	_, err := m.api.OrganizationPipelines.UnpausePipeline(params, m.api.Credentials(&org))
 	if err != nil {
 		return NewApiError(err)
 	}
@@ -90,7 +90,7 @@ func (m *middleware) UpdatePipeline(org, project, env, pipeline, variables strin
 
 	params.SetBody(body)
 
-	resp, err := m.api.OrganizationPipelines.UpdatePipeline(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationPipelines.UpdatePipeline(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -124,7 +124,7 @@ func (m *middleware) DiffPipeline(org, project, env, pipeline, variables string)
 		return nil, err
 	}
 
-	resp, err := m.api.OrganizationPipelines.DiffPipeline(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationPipelines.DiffPipeline(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -169,7 +169,7 @@ func (m *middleware) CreatePipeline(org, project, env, pipeline, variables, usec
 	}
 
 	params.SetBody(body)
-	resp, err := m.api.OrganizationPipelines.CreatePipeline(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationPipelines.CreatePipeline(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -194,7 +194,7 @@ func (m *middleware) GetPipelineJob(org, project, env, job string) (*models.Job,
 	params.SetInpathPipelineName(pipelineName)
 	params.SetJobName(job)
 
-	resp, err := m.api.OrganizationPipelinesJobs.GetJob(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationPipelinesJobs.GetJob(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -219,7 +219,7 @@ func (m *middleware) ListPipelineJobsBuilds(org, project, env, job string) ([]*m
 	params.SetInpathPipelineName(pipelineName)
 	params.SetJobName(job)
 
-	resp, err := m.api.OrganizationPipelinesJobsBuild.GetBuilds(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationPipelinesJobsBuild.GetBuilds(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -243,7 +243,7 @@ func (m *middleware) ListPipelineJobs(org, project, env string) ([]*models.Job, 
 	params.SetProjectCanonical(project)
 	params.SetInpathPipelineName(pipelineName)
 
-	resp, err := m.api.OrganizationPipelinesJobs.GetJobs(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationPipelinesJobs.GetJobs(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -268,7 +268,7 @@ func (m *middleware) PausePipelineJob(org, project, env, job string) error {
 	params.SetInpathPipelineName(pipelineName)
 	params.SetJobName(job)
 
-	_, err := m.api.OrganizationPipelinesJobs.PauseJob(params, common.ClientCredentials(&org))
+	_, err := m.api.OrganizationPipelinesJobs.PauseJob(params, m.api.Credentials(&org))
 	if err != nil {
 		return NewApiError(err)
 	}
@@ -286,7 +286,7 @@ func (m *middleware) UnpausePipelineJob(org, project, env, job string) error {
 	params.SetInpathPipelineName(pipelineName)
 	params.SetJobName(job)
 
-	_, err := m.api.OrganizationPipelinesJobs.UnpauseJob(params, common.ClientCredentials(&org))
+	_, err := m.api.OrganizationPipelinesJobs.UnpauseJob(params, m.api.Credentials(&org))
 	if err != nil {
 		return NewApiError(err)
 	}
@@ -304,7 +304,7 @@ func (m *middleware) TriggerPipelineBuild(org, project, env, job string) error {
 	params.SetInpathPipelineName(pipelineName)
 	params.SetJobName(job)
 
-	_, err := m.api.OrganizationPipelinesJobsBuild.CreateBuild(params, common.ClientCredentials(&org))
+	_, err := m.api.OrganizationPipelinesJobsBuild.CreateBuild(params, m.api.Credentials(&org))
 	if err != nil {
 		return NewApiError(err)
 	}
@@ -317,7 +317,7 @@ func (m *middleware) ListPipelines(org string) ([]*models.Pipeline, error) {
 	params := organization_pipelines.NewGetPipelinesParams()
 	params.SetOrganizationCanonical(org)
 
-	resp, err := m.api.OrganizationPipelines.GetPipelines(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationPipelines.GetPipelines(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -341,7 +341,7 @@ func (m *middleware) GetPipeline(org, project, env string) (*models.Pipeline, er
 	params.SetProjectCanonical(project)
 	params.SetInpathPipelineName(pipelineName)
 
-	resp, err := m.api.OrganizationPipelines.GetPipeline(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationPipelines.GetPipeline(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -364,7 +364,7 @@ func (m *middleware) SyncedPipeline(org, project, env string) (*models.PipelineS
 	params.SetOrganizationCanonical(org)
 	params.SetInpathPipelineName(pipelineName)
 
-	resp, err := m.api.OrganizationPipelines.SyncedPipeline(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationPipelines.SyncedPipeline(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}

--- a/cmd/cycloid/middleware/project.go
+++ b/cmd/cycloid/middleware/project.go
@@ -15,7 +15,7 @@ func (m *middleware) ListProjects(org string) ([]*models.Project, error) {
 	params := organization_projects.NewGetProjectsParams()
 	params.SetOrganizationCanonical(org)
 
-	resp, err := m.api.OrganizationProjects.GetProjects(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationProjects.GetProjects(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -37,7 +37,7 @@ func (m *middleware) GetProject(org, project string) (*models.Project, error) {
 	params.SetOrganizationCanonical(org)
 	params.SetProjectCanonical(project)
 
-	resp, err := m.api.OrganizationProjects.GetProject(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationProjects.GetProject(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -106,7 +106,7 @@ func (m *middleware) CreateProject(org, projectName, projectCanonical, env, pipe
 	}
 
 	params.SetBody(body)
-	resp, err := m.api.OrganizationProjects.CreateProject(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationProjects.CreateProject(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -143,7 +143,7 @@ func (m *middleware) UpdateProject(org, projectName, projectCanonical string, en
 	}
 
 	params.SetBody(body)
-	resp, err := m.api.OrganizationProjects.UpdateProject(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationProjects.UpdateProject(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -165,7 +165,7 @@ func (m *middleware) DeleteProjectEnv(org, project, env string) error {
 	params.SetProjectCanonical(project)
 	params.SetEnvironmentCanonical(env)
 
-	_, err := m.api.OrganizationProjects.DeleteProjectEnvironment(params, common.ClientCredentials(&org))
+	_, err := m.api.OrganizationProjects.DeleteProjectEnvironment(params, m.api.Credentials(&org))
 	if err != nil {
 		return NewApiError(err)
 	}
@@ -178,7 +178,7 @@ func (m *middleware) DeleteProject(org, project string) error {
 	params.SetOrganizationCanonical(org)
 	params.SetProjectCanonical(project)
 
-	_, err := m.api.OrganizationProjects.DeleteProject(params, common.ClientCredentials(&org))
+	_, err := m.api.OrganizationProjects.DeleteProject(params, m.api.Credentials(&org))
 	if err != nil {
 		return NewApiError(err)
 	}

--- a/cmd/cycloid/middleware/roles.go
+++ b/cmd/cycloid/middleware/roles.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"github.com/cycloidio/cycloid-cli/client/client/organization_roles"
 	"github.com/cycloidio/cycloid-cli/client/models"
-	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
 	strfmt "github.com/go-openapi/strfmt"
 )
 
@@ -11,7 +10,7 @@ func (m *middleware) ListRoles(org string) ([]*models.Role, error) {
 	params := organization_roles.NewGetRolesParams()
 	params.SetOrganizationCanonical(org)
 
-	resp, err := m.api.OrganizationRoles.GetRoles(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationRoles.GetRoles(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -33,7 +32,7 @@ func (m *middleware) GetRole(org, role string) (*models.Role, error) {
 	params.SetOrganizationCanonical(org)
 	params.SetRoleCanonical(role)
 
-	resp, err := m.api.OrganizationRoles.GetRole(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationRoles.GetRole(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -55,7 +54,7 @@ func (m *middleware) DeleteRole(org, role string) error {
 	params.SetOrganizationCanonical(org)
 	params.SetRoleCanonical(role)
 
-	_, err := m.api.OrganizationRoles.DeleteRole(params, common.ClientCredentials(&org))
+	_, err := m.api.OrganizationRoles.DeleteRole(params, m.api.Credentials(&org))
 	if err != nil {
 		return NewApiError(err)
 	}

--- a/cmd/cycloid/middleware/stacks.go
+++ b/cmd/cycloid/middleware/stacks.go
@@ -5,7 +5,6 @@ import (
 	"github.com/cycloidio/cycloid-cli/client/client/service_catalogs"
 
 	"github.com/cycloidio/cycloid-cli/client/models"
-	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
 	strfmt "github.com/go-openapi/strfmt"
 	"gopkg.in/yaml.v3"
 )
@@ -15,7 +14,7 @@ func (m *middleware) ListStacks(org string) ([]*models.ServiceCatalog, error) {
 	params := service_catalogs.NewListServiceCatalogsParams()
 	params.SetOrganizationCanonical(org)
 
-	resp, err := m.api.ServiceCatalogs.ListServiceCatalogs(params, common.ClientCredentials(&org))
+	resp, err := m.api.ServiceCatalogs.ListServiceCatalogs(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -37,7 +36,7 @@ func (m *middleware) GetStack(org, ref string) (*models.ServiceCatalog, error) {
 	params.SetOrganizationCanonical(org)
 	params.SetServiceCatalogRef(ref)
 
-	resp, err := m.api.ServiceCatalogs.GetServiceCatalog(params, common.ClientCredentials(&org))
+	resp, err := m.api.ServiceCatalogs.GetServiceCatalog(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -59,7 +58,7 @@ func (m *middleware) GetStackConfig(org, ref string) (interface{}, error) {
 	params.SetOrganizationCanonical(org)
 	params.SetServiceCatalogRef(ref)
 
-	resp, err := m.api.ServiceCatalogs.GetServiceCatalogConfig(params, common.ClientCredentials(&org))
+	resp, err := m.api.ServiceCatalogs.GetServiceCatalogConfig(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}
@@ -136,7 +135,7 @@ func (m *middleware) ValidateForm(org string, rawForms []byte) (*models.FormsVal
 	}
 
 	params.SetBody(body)
-	resp, err := m.api.OrganizationForms.ValidateFormsFile(params, common.ClientCredentials(&org))
+	resp, err := m.api.OrganizationForms.ValidateFormsFile(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, NewApiError(err)
 	}

--- a/cmd/cycloid/middleware/terracost.go
+++ b/cmd/cycloid/middleware/terracost.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cycloidio/cycloid-cli/client/client/cost_estimation"
 	"github.com/cycloidio/cycloid-cli/client/models"
-	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
 )
 
 // CostEstimation will consume the backend API endpoint for cost estimation
@@ -18,7 +17,7 @@ func (m *middleware) CostEstimation(org string, plan []byte) (*models.CostEstima
 		Tfplan: &tfplan,
 	})
 
-	res, err := m.api.CostEstimation.CostEstimateTfPlan(params, common.ClientCredentials(&org))
+	res, err := m.api.CostEstimation.CostEstimateTfPlan(params, m.api.Credentials(&org))
 	if err != nil {
 		return nil, fmt.Errorf("unable to estimate cost insfrastructure: %w", NewApiError(err))
 	}


### PR DESCRIPTION
Closes #229 and closes #223

```
~/repos/cycloid-cli [fg-229] $> wp make local-e2e-test
Local BE is up!
Running Local e2e tests!
make[1]: Entering directory '/home/xescugc/repos/cycloid-cli'
Using API url: http://127.0.0.1:3001 (from $CY_API_URL)
Using GIT: git@172.42.0.14:/git-server/repos/backend-test-config-repo.git (from $CY_TEST_GIT_CR_URL)
?       github.com/cycloidio/cycloid-cli        [no test files]
?       github.com/cycloidio/cycloid-cli/client/client  [no test files]
?       github.com/cycloidio/cycloid-cli/client/client/cost_estimation  [no test files]
?       github.com/cycloidio/cycloid-cli/client/client/cycloid  [no test files]
?       github.com/cycloidio/cycloid-cli/client/client/organization_api_keys    [no test files]
?       github.com/cycloidio/cycloid-cli/client/client/organization_children    [no test files]
?       github.com/cycloidio/cycloid-cli/client/client/organization_config_repositories [no test files]
?       github.com/cycloidio/cycloid-cli/client/client/organization_credentials [no test files]
?       github.com/cycloidio/cycloid-cli/client/client/organization_external_backends   [no test files]
?       github.com/cycloidio/cycloid-cli/client/client/organization_forms       [no test files]
?       github.com/cycloidio/cycloid-cli/client/client/organization_infrastructure_policies     [no test files]
?       github.com/cycloidio/cycloid-cli/client/client/organization_invitations [no test files]
?       github.com/cycloidio/cycloid-cli/client/client/organization_kpis        [no test files]
?       github.com/cycloidio/cycloid-cli/client/client/organization_members     [no test files]
?       github.com/cycloidio/cycloid-cli/client/client/organization_pipelines   [no test files]
?       github.com/cycloidio/cycloid-cli/client/client/organization_pipelines_jobs      [no test files]
?       github.com/cycloidio/cycloid-cli/client/client/organization_pipelines_jobs_build        [no test files]
?       github.com/cycloidio/cycloid-cli/client/client/organization_projects    [no test files]
?       github.com/cycloidio/cycloid-cli/client/client/organization_roles       [no test files]
?       github.com/cycloidio/cycloid-cli/client/client/organization_service_catalog_sources     [no test files]
?       github.com/cycloidio/cycloid-cli/client/client/organization_workers     [no test files]
?       github.com/cycloidio/cycloid-cli/client/client/organizations    [no test files]
?       github.com/cycloidio/cycloid-cli/client/client/service_catalogs [no test files]
?       github.com/cycloidio/cycloid-cli/client/client/user     [no test files]
?       github.com/cycloidio/cycloid-cli/client/models  [no test files]
?       github.com/cycloidio/cycloid-cli/cmd    [no test files]
?       github.com/cycloidio/cycloid-cli/cmd/cycloid    [no test files]
?       github.com/cycloidio/cycloid-cli/cmd/cycloid/apikey     [no test files]
?       github.com/cycloidio/cycloid-cli/cmd/cycloid/catalog-repositories       [no test files]
?       github.com/cycloidio/cycloid-cli/cmd/cycloid/config-repositories        [no test files]
?       github.com/cycloidio/cycloid-cli/cmd/cycloid/creds      [no test files]
?       github.com/cycloidio/cycloid-cli/cmd/cycloid/events     [no test files]
?       github.com/cycloidio/cycloid-cli/cmd/cycloid/external-backends  [no test files]
?       github.com/cycloidio/cycloid-cli/cmd/cycloid/internal   [no test files]
?       github.com/cycloidio/cycloid-cli/cmd/cycloid/kpis       [no test files]
?       github.com/cycloidio/cycloid-cli/cmd/cycloid/login      [no test files]
?       github.com/cycloidio/cycloid-cli/cmd/cycloid/members    [no test files]
?       github.com/cycloidio/cycloid-cli/cmd/cycloid/infrapolicies      [no test files]
ok      github.com/cycloidio/cycloid-cli/cmd/cycloid/common     (cached)
?       github.com/cycloidio/cycloid-cli/cmd/cycloid/organizations      [no test files]
?       github.com/cycloidio/cycloid-cli/cmd/cycloid/pipelines  [no test files]
?       github.com/cycloidio/cycloid-cli/cmd/cycloid/projects   [no test files]
?       github.com/cycloidio/cycloid-cli/cmd/cycloid/roles      [no test files]
?       github.com/cycloidio/cycloid-cli/cmd/cycloid/stacks     [no test files]
ok      github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware (cached)
?       github.com/cycloidio/cycloid-cli/cmd/cycloid/terracost  [no test files]
?       github.com/cycloidio/cycloid-cli/config [no test files]
?       github.com/cycloidio/cycloid-cli/internal/version       [no test files]
?       github.com/cycloidio/cycloid-cli/printer        [no test files]
ok      github.com/cycloidio/cycloid-cli/e2e    (cached)
ok      github.com/cycloidio/cycloid-cli/printer/factory        (cached)
ok      github.com/cycloidio/cycloid-cli/printer/json   (cached)
ok      github.com/cycloidio/cycloid-cli/printer/table  (cached)
ok      github.com/cycloidio/cycloid-cli/printer/yaml   (cached)
make[1]: Leaving directory '/home/xescugc/repos/cycloid-cli
```