### PR TITLE
cmd/cycloid/middleware: Added the Organization Update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,11 +78,11 @@ AWS_ACCOUNT_ID        ?= $(shell vault read -field=account_id secret/cycloid/aws
 # Local BE
 LOCAL_BE_GIT_PATH ?= ../youdeploy-http-api
 YD_API_TAG        ?= staging
-API_LICENCE_KEY   ?= (api-e2e-lincese-key)
+API_LICENCE_KEY   ?= 
 
 .PHONY: help
 help: ## Show this help
-	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/:.*##/:##/' | column -t -s '##'
+	@grep -F -h "##" $(MAKEFILE_LIST) | grep -F -v fgrep | sed -e 's/:.*##/:##/' | column -t -s '##'
 
 .PHONY: build
 build: ## Builds the binary
@@ -130,6 +130,7 @@ ecr-connect: ## Login to ecr, requires aws cli installed
 .PHONY: start-local-be
 start-local-be: ## Starts local BE instance. Note! Only for cycloid developers
 	@if [ ! -d ${LOCAL_BE_GIT_PATH} ]; then echo "Unable to find BE at LOCAL_BE_GIT_PATH"; exit 1; fi;
+	@if [ -z "$$API_LICENCE_KEY" ]; then echo "API_LICENCE_KEY is not set"; exit 1; fi; \
 	@echo "Starting Local BE..."
 	@echo "Generating fake data to be used in the tests..."
 	@cd $(LOCAL_BE_GIT_PATH) && sed -i '/cost-explorer-es/d' config.yml

--- a/cmd/cycloid/middleware/middleware.go
+++ b/cmd/cycloid/middleware/middleware.go
@@ -48,6 +48,7 @@ type Middleware interface {
 	UpdateMembers(org, name, role string) (*models.MemberOrg, error)
 
 	CreateOrganization(name string) (*models.Organization, error)
+	UpdateOrganization(org, name string) (*models.Organization, error)
 	DeleteOrganization(org string) error
 	GetOrganization(org string) (*models.Organization, error)
 	ListOrganizations() ([]*models.Organization, error)

--- a/cmd/cycloid/middleware/organization.go
+++ b/cmd/cycloid/middleware/organization.go
@@ -35,6 +35,32 @@ func (m *middleware) CreateOrganization(name string) (*models.Organization, erro
 	return d, nil
 }
 
+func (m *middleware) UpdateOrganization(can, name string) (*models.Organization, error) {
+
+	params := organizations.NewUpdateOrgParams()
+	params.SetOrganizationCanonical(can)
+
+	body := &models.UpdateOrganization{
+		Name: &name,
+	}
+
+	params.SetBody(body)
+	err := body.Validate(strfmt.Default)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to validate request body")
+	}
+
+	resp, err := m.api.Organizations.UpdateOrg(params, m.api.Credentials(&can))
+	if err != nil {
+		return nil, NewApiError(err)
+	}
+
+	p := resp.GetPayload()
+
+	d := p.Data
+	return d, nil
+}
+
 func (m *middleware) GetOrganization(org string) (*models.Organization, error) {
 
 	params := organizations.NewGetOrgParams()

--- a/cmd/cycloid/organizations/cmd.go
+++ b/cmd/cycloid/organizations/cmd.go
@@ -16,6 +16,7 @@ func NewCommands() *cobra.Command {
 	}
 	cmd.AddCommand(
 		NewCreateCommand(),
+		NewUpdateCommand(),
 		NewListCommand(),
 		NewListWorkersCommand(),
 		NewDeleteCommand(),

--- a/cmd/cycloid/organizations/update.go
+++ b/cmd/cycloid/organizations/update.go
@@ -1,0 +1,61 @@
+package organizations
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/internal"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/printer"
+	"github.com/cycloidio/cycloid-cli/printer/factory"
+)
+
+// This command have been Hidden because it is not compatible with API key login.
+// Advanced user still can use it passing a user token in CY_TOKEN env var during a login.
+func NewUpdateCommand() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "update",
+		Short: "update an organization",
+		Example: `
+	# update an organization foo
+	cy organization update --org org --name foo
+`,
+		RunE:    update,
+		PreRunE: internal.CheckAPIAndCLIVersion,
+	}
+
+	common.RequiredPersistentFlag(common.WithFlagOrg, cmd)
+	common.RequiredFlag(WithFlagName, cmd)
+
+	return cmd
+}
+
+func update(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	name, err := cmd.Flags().GetString("name")
+	if err != nil {
+		return err
+	}
+
+	org, err := cmd.Flags().GetString("org")
+	if err != nil {
+		return errors.Wrap(err, "unable get org flag")
+	}
+
+	output, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return errors.Wrap(err, "unable to get output flag")
+	}
+
+	// fetch the printer from the factory
+	p, err := factory.GetPrinter(output)
+	if err != nil {
+		return errors.Wrap(err, "unable to get printer")
+	}
+
+	o, err := m.UpdateOrganization(org, name)
+	return printer.SmartPrint(p, o, err, "unable to update organization", printer.Options{}, cmd.OutOrStdout())
+}


### PR DESCRIPTION
Changed the `fgrep` because it was printing

> fgrep: warning: fgrep is obsolescent; using grep -F                                                                                                                                                                 

Also made the `$API_LICENCE_KEY` empty and check if set on the tests so it'll fail if not set correctly.

This cannot be tested on the `e2e` because it updates the token and it requires a refresh.

Close #245 