### PR TITLE
feat/cmd: add draft of cr template command

### DIFF
--- a/cmd/cycloid/catalog-repositories/cmd.go
+++ b/cmd/cycloid/catalog-repositories/cmd.go
@@ -22,7 +22,9 @@ func NewCommands() *cobra.Command {
 		NewDeleteCommand(),
 		NewListCommand(),
 		NewGetCommand(),
-		NewRefreshCommand())
+		NewRefreshCommand(),
+		NewTemplateCommand(),
+	)
 
 	return cmd
 }

--- a/cmd/cycloid/catalog-repositories/create.go
+++ b/cmd/cycloid/catalog-repositories/create.go
@@ -19,8 +19,7 @@ func NewCreateCommand() *cobra.Command {
 	cy --org my-org catalog-repo create --branch stacks --cred my-cred --url "git@github.com:my/repo.git" --name my-catalog-name
 
 	# create a catalog repository using public git repository
-	cy --org my-org catalog-repo create --branch stacks --url "https://github.com:my/repo.git" --name my-catalog-name
-`,
+	cy --org my-org catalog-repo create --branch stacks --url "https://github.com:my/repo.git" --name my-catalog-name `,
 		RunE: createCatalogRepository,
 	}
 

--- a/cmd/cycloid/catalog-repositories/template.go
+++ b/cmd/cycloid/catalog-repositories/template.go
@@ -1,0 +1,112 @@
+package catalogRepositories
+
+import (
+	"time"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/printer"
+	"github.com/cycloidio/cycloid-cli/printer/factory"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func NewTemplateCommand() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "template",
+		Short: "template a stack for a catalog repository",
+		Example: `
+  Create a stack from a template using a template repository
+  cy --org my-org cr template \
+    -r my-catalog-repo \
+    -s source-catalog:ref \
+    --stack-name "My stack stack-name" \
+    --canonical my-stack-canonical \
+    --use-case stack-use-case
+`,
+		RunE: NewStackFromTemplate,
+	}
+
+	timestamp := uint64(time.Now().Unix())
+
+	cmd.Flags().StringP("service-catalog-reference", "r", "", "[required] catalog reference")
+	cmd.MarkFlagRequired("service-catalog-reference")
+	cmd.Flags().StringP("service-catalog-source-canonical", "s", "", "[required] catalog source")
+	cmd.MarkFlagRequired("service-catalog-source-canonical")
+	cmd.Flags().StringP("stack-name", "n", "", "[required] stack stack-name")
+	cmd.MarkFlagRequired("stack-name")
+	cmd.Flags().StringP("stack-canonical", "c", "", "[required] stack canonical")
+	cmd.MarkFlagRequired("stack-canonical")
+	cmd.Flags().StringP("use-case", "u", "", "[required] stack use-case")
+	cmd.MarkFlagRequired("use-case")
+	cmd.Flags().StringP("author", "a", "", "stack author")
+	cmd.Flags().Uint64("created-at", timestamp, "stack created-at")
+	cmd.Flags().Uint64("updated-at", timestamp, "stack updated-at")
+
+	return cmd
+}
+
+func NewStackFromTemplate(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cmd.Flags().GetString("org")
+	if err != nil {
+		return err
+	}
+
+	service_catalog_reference, err := cmd.Flags().GetString("service-catalog-reference")
+	if err != nil {
+		return err
+	}
+
+	stack_name, err := cmd.Flags().GetString("stack-name")
+	if err != nil {
+		return err
+	}
+
+	stack_canonical, err := cmd.Flags().GetString("stack-canonical")
+	if err != nil {
+		return err
+	}
+
+	author, err := cmd.Flags().GetString("author")
+	if err != nil {
+		return err
+	}
+
+	service_catalog_source_canonical, err := cmd.Flags().GetString("service-catalog-source-canonical")
+	if err != nil {
+		return err
+	}
+
+	use_case, err := cmd.Flags().GetString("use-case")
+	if err != nil {
+		return err
+	}
+
+	created_at, err := cmd.Flags().GetUint64("created-at")
+	if err != nil {
+		return err
+	}
+
+	updated_at, err := cmd.Flags().GetUint64("updated-at")
+	if err != nil {
+		return err
+	}
+
+	// Get output settings
+	output, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return err
+	}
+
+	p, err := factory.GetPrinter(output)
+	if err != nil {
+		return errors.Wrap(err, "unable to get printer")
+	}
+
+	// Send result to printer
+	stack, err := m.NewServiceCatalogFromTemplate(org, service_catalog_reference, stack_name, stack_canonical, author, service_catalog_source_canonical, use_case, created_at, updated_at)
+	return printer.SmartPrint(p, stack, err, "failed to template stack", printer.Options{}, cmd.OutOrStdout())
+}

--- a/cmd/cycloid/middleware/catalog-repositories.go
+++ b/cmd/cycloid/middleware/catalog-repositories.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"github.com/cycloidio/cycloid-cli/client/client/organization_service_catalog_sources"
+	"github.com/cycloidio/cycloid-cli/client/client/service_catalogs"
 	"github.com/cycloidio/cycloid-cli/client/models"
 	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
 	strfmt "github.com/go-openapi/strfmt"
@@ -164,4 +165,31 @@ func (m *middleware) RefreshCatalogRepository(org, catalogRepo string) (*models.
 	d := p.Data
 
 	return d, err
+}
+
+func (m *middleware) NewServiceCatalogFromTemplate(org string, serviceCatalog string, name string, canonical string, author string, serviceCatalogSourceCanonincal string, useCase string, createdAt uint64, updatedAt uint64) (*models.ServiceCatalog, error) {
+	params := service_catalogs.NewCreateServiceCatalogFromTemplateParams()
+	params.SetOrganizationCanonical(org)
+	params.SetServiceCatalogRef(serviceCatalog)
+	params.Body = &models.NewServiceCatalogFromTemplate{
+		Name:                          &name,
+		Canonical:                     &canonical,
+		Author:                        author,
+		ServiceCatalogSourceCanonical: &serviceCatalogSourceCanonincal,
+		UseCase:                       &useCase,
+		CreatedAt:                     &createdAt,
+		UpdatedAt:                     &updatedAt,
+	}
+	resp, err := m.api.ServiceCatalogs.CreateServiceCatalogFromTemplate(params, common.ClientCredentials(&org))
+	if err != nil {
+		return nil, err
+	}
+	p := resp.GetPayload()
+	err = p.Validate(strfmt.Default)
+	if err != nil {
+		return nil, err
+	}
+
+	d := p.Data
+	return d, nil
 }

--- a/cmd/cycloid/middleware/middleware.go
+++ b/cmd/cycloid/middleware/middleware.go
@@ -16,6 +16,7 @@ type Middleware interface {
 	ListCatalogRepositories(org string) ([]*models.ServiceCatalogSource, error)
 	RefreshCatalogRepository(org, catalogRepo string) (*models.ServiceCatalogChanges, error)
 	UpdateCatalogRepository(org, name, url, branch, catalogRepo, cred string) (*models.ServiceCatalogSource, error)
+	NewServiceCatalogFromTemplate(org string, serviceCatalog string, name string, canonical string, author string, serviceCatalogSourceCanonincal string, useCase string, createdAt uint64, updatedAt uint64) (*models.ServiceCatalog, error)
 	GetStackConfig(org, ref string) (interface{}, error)
 
 	CreateConfigRepository(org, name, url, branch, cred string, setDefault bool) (*models.ConfigRepository, error)


### PR DESCRIPTION
This PR aims to add a `cy cr template` command to template a stack using the [createServiceCatalogFromTemplate endpoint](https://docs.cycloid.io/api/#operation/createServiceCatalogFromTemplate).

Feel free to correct me.