### PR TITLE
func/cli: remove usage print on error.

### DIFF
--- a/cmd/cycloid.go
+++ b/cmd/cycloid.go
@@ -63,6 +63,9 @@ func NewRootCommand() *cobra.Command {
 	rootCmd.PersistentFlags().Bool("insecure", false, "Decide to skip or not TLS verification")
 	viper.BindPFlag("insecure", rootCmd.PersistentFlags().Lookup("insecure"))
 
+	// Remove usage on error, this is annoying in scripting
+	rootCmd.SilenceUsage = true
+
 	AttachCommands(rootCmd)
 
 	return rootCmd


### PR DESCRIPTION
Printing help on each CLI error is really annoying when making/debugging scripts on the CLI.

Users are able to repeat the last command and add --help.