### PR TITLE
fix/verbosity: Make the parameter relevant for warning messages

### DIFF
--- a/cmd/cycloid/internal/version.go
+++ b/cmd/cycloid/internal/version.go
@@ -9,10 +9,20 @@ import (
 	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
 	"github.com/cycloidio/cycloid-cli/internal/version"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func warning(out io.Writer, msg string) {
-	fmt.Fprintf(out, "\033[1;35m%s\033[0m\n", msg)
+	switch viper.GetString("verbosity") {
+	case "info", "debug", "warning":
+		// This is still dirty, we should detect if the current
+		// terminal is able to support colors
+		// But that would be for another PR.
+		fmt.Fprintf(out, "\033[1;35m%s\033[0m\n", msg)
+		break
+	default:
+		break
+	}
 }
 
 func CheckAPIAndCLIVersion(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Another thing that grinds my gear: 

![image](https://github.com/cycloidio/cycloid-cli/assets/148750436/cb15deb3-774a-4bc9-9ad3-69c1b9474a87)

So I put a dumb fix, this could expand to a full check output messages and implement actual
verbosity levels.