### PR TITLE
Add get stack config

### DIFF
--- a/cmd/cycloid/common/helpers.go
+++ b/cmd/cycloid/common/helpers.go
@@ -308,12 +308,7 @@ func EntityGetValue(entity *models.FormEntity, getCurrent bool) any {
 	}
 }
 
-func ParseFormsConfig(conf *models.ProjectEnvironmentConfig, useCase string, getCurrent bool) (vars map[string]map[string]map[string]any, err error) {
-	form, err := GetFormsUseCase(conf.Forms.UseCases, useCase)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to extract forms data from project config.")
-	}
-
+func ParseFormsConfig(form *models.FormUseCase, getCurrent bool) (vars map[string]map[string]map[string]any, err error) {
 	vars = make(map[string]map[string]map[string]any)
 	for _, section := range form.Sections {
 		if section == nil {
@@ -334,11 +329,11 @@ func ParseFormsConfig(conf *models.ProjectEnvironmentConfig, useCase string, get
 				}
 
 				value := EntityGetValue(varEntity, getCurrent)
-				// We have to strings.ToLower() the keys otherwise, it will not be
-				// recognized as input for a create-env
-				vars[strings.ToLower(*varEntity.Name)] = value
+				vars[*varEntity.Key] = value
 			}
 
+			// We have to strings.ToLower() the groups and sections names
+			// otherwise, it will not be recognized as input for a create-env
 			groups[strings.ToLower(*group.Name)] = vars
 		}
 

--- a/cmd/cycloid/middleware/stacks.go
+++ b/cmd/cycloid/middleware/stacks.go
@@ -12,7 +12,6 @@ import (
 )
 
 func (m *middleware) ListStacks(org string) ([]*models.ServiceCatalog, error) {
-
 	params := service_catalogs.NewListServiceCatalogsParams()
 	params.SetOrganizationCanonical(org)
 
@@ -33,7 +32,6 @@ func (m *middleware) ListStacks(org string) ([]*models.ServiceCatalog, error) {
 }
 
 func (m *middleware) GetStack(org, ref string) (*models.ServiceCatalog, error) {
-
 	params := service_catalogs.NewGetServiceCatalogParams()
 	params.SetOrganizationCanonical(org)
 	params.SetServiceCatalogRef(ref)
@@ -55,7 +53,6 @@ func (m *middleware) GetStack(org, ref string) (*models.ServiceCatalog, error) {
 }
 
 func (m *middleware) GetStackConfig(org, ref string) (interface{}, error) {
-
 	params := service_catalogs.NewGetServiceCatalogConfigParams()
 	params.SetOrganizationCanonical(org)
 	params.SetServiceCatalogRef(ref)

--- a/cmd/cycloid/projects/create-env.go
+++ b/cmd/cycloid/projects/create-env.go
@@ -332,7 +332,12 @@ func createEnv(cmd *cobra.Command, args []string) error {
 		return printer.SmartPrint(p, inputs[0].Vars, errors.Wrap(err, errMsg), "", printer.Options{}, cmd.OutOrStdout())
 	}
 
-	formsConfig, err := common.ParseFormsConfig(config, usecase, true)
+	form, err := common.GetFormsUseCase(config.Forms.UseCases, usecase)
+	if err != nil {
+		return errors.Wrap(err, "failed to extract forms data from project config.")
+	}
+
+	formsConfig, err := common.ParseFormsConfig(form, true)
 	if err != nil {
 		return printer.SmartPrint(p, inputs[0].Vars, errors.Wrap(err, errMsg), "", printer.Options{}, cmd.OutOrStdout())
 	}

--- a/cmd/cycloid/projects/get-env.go
+++ b/cmd/cycloid/projects/get-env.go
@@ -111,7 +111,12 @@ func getEnvConfig(cmd *cobra.Command, args []string) error {
 		return printer.SmartPrint(p, nil, err, fmt.Sprint("failed to fetch project '", project, "' config for env '", env, "' in org '", org, "'"), printer.Options{}, cmd.OutOrStderr())
 	}
 
-	formData, err := common.ParseFormsConfig(resp, *resp.UseCase, !getDefault)
+	form, err := common.GetFormsUseCase(resp.Forms.UseCases, *resp.UseCase)
+	if err != nil {
+		return errors.Wrap(err, "failed to extract forms data from project config.")
+	}
+
+	formData, err := common.ParseFormsConfig(form, !getDefault)
 	if err != nil {
 		return printer.SmartPrint(p, nil, err, "failed to get stack config, parsing failed.", printer.Options{}, cmd.OutOrStdout())
 	}

--- a/cmd/cycloid/stacks/cmd.go
+++ b/cmd/cycloid/stacks/cmd.go
@@ -17,6 +17,7 @@ func NewCommands() *cobra.Command {
 	cmd.AddCommand(
 		NewListCommand(),
 		NewGetCommand(),
+		NewGetConfigCommand(),
 		NewValidateFormCmd(),
 	)
 

--- a/cmd/cycloid/stacks/get-config.go
+++ b/cmd/cycloid/stacks/get-config.go
@@ -1,0 +1,109 @@
+package stacks
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/client/models"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/internal"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/printer"
+	"github.com/cycloidio/cycloid-cli/printer/factory"
+)
+
+func NewGetConfigCommand() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "get-config <ref?> <use-case?> [flags]",
+		Short: "get a stack configuration",
+		Example: `
+cy --org my-org stacks get-config my:stack-ref stack-usecase
+`,
+		PreRunE: internal.CheckAPIAndCLIVersion,
+		RunE:    getConfig,
+		Args:    cobra.RangeArgs(0, 2),
+	}
+	cmd.Flags().String("org", "", "organization")
+	cmd.MarkFlagRequired("org")
+	cmd.Flags().StringP("ref", "r", "", "referential of the stack")
+	cmd.Flags().StringP("use-case", "u", "", "usecase you want")
+
+	return cmd
+}
+
+func getConfig(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cmd.Flags().GetString("org")
+	if err != nil {
+		return err
+	}
+
+	ref, err := cmd.Flags().GetString("ref")
+	if len(args) >= 1 && ref == "" {
+		ref = args[0]
+	} else if ref == "" {
+		return fmt.Errorf("missing ref argument.")
+	}
+
+	useCase, err := cmd.Flags().GetString("use-case")
+	if len(args) == 2 && useCase == "" {
+		useCase = args[1]
+	} else if useCase == "" {
+		return fmt.Errorf("missing use-case argument.")
+	}
+
+	internal.Debug("ref: ", ref, "usecase:", useCase)
+
+	output, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return errors.Wrap(err, "unable to get output flag")
+	}
+
+	// Default output is in JSON
+	if output == "table" {
+		output = "json"
+	}
+
+	// fetch the printer from the factory
+	p, err := factory.GetPrinter(output)
+	if err != nil {
+		return errors.Wrap(err, "unable to get printer")
+	}
+
+	s, err := m.GetStackConfig(org, ref)
+	if err != nil {
+		return printer.SmartPrint(p, nil, err, "unable to get the stack configuration", printer.Options{}, cmd.OutOrStdout())
+	}
+
+	data, ok := s.(map[string]interface{})
+	if !ok {
+		return printer.SmartPrint(p, nil, fmt.Errorf("failed to parse stack data"), "", printer.Options{}, cmd.OutOrStdout())
+	}
+
+	useCaseData, ok := data[useCase].(map[string]interface{})
+	if !ok {
+		return printer.SmartPrint(p, nil, fmt.Errorf("failed to parse stack config data: %v:", data), "", printer.Options{}, cmd.OutOrStdout())
+	}
+
+	// Type casting is not working but marshall/unmashall works
+	// TODO: Clean this or ask backend to return a typed response
+	jsonData, err := json.Marshal(useCaseData["forms"])
+	if err != nil {
+		return errors.Wrap(err, "failed to marshall config")
+	}
+
+	var d *models.FormUseCase
+	err = json.Unmarshal(jsonData, &d)
+
+	formConfig, err := common.ParseFormsConfig(d, false)
+	if err != nil {
+		return printer.SmartPrint(p, nil, err, "unable to parse stack config", printer.Options{}, cmd.OutOrStdout())
+	}
+
+	return printer.SmartPrint(p, formConfig, err, "unable to get stack", printer.Options{}, cmd.OutOrStdout())
+}

--- a/cmd/cycloid/stacks/get.go
+++ b/cmd/cycloid/stacks/get.go
@@ -59,3 +59,5 @@ func get(cmd *cobra.Command, args []string) error {
 	s, err := m.GetStack(org, ref)
 	return printer.SmartPrint(p, s, err, "unable to get stack", printer.Options{}, cmd.OutOrStdout())
 }
+
+


### PR DESCRIPTION
- Add a `cy stacks get-config <ref> <use-case>` to retrieve a stack default config
- Fix forms config parsing for `cy projects create-stackforms-env` not sending the correct vars keys.