### PR TITLE
frederichampel ops 159 cli fix get env return null

### DIFF
--- a/cmd/cycloid/middleware/creds.go
+++ b/cmd/cycloid/middleware/creds.go
@@ -11,7 +11,6 @@ import (
 )
 
 func (m *middleware) CreateCredential(org, name, cType string, rawCred *models.CredentialRaw, path, can, description string) (*models.Credential, error) {
-
 	params := organization_credentials.NewCreateCredentialParams()
 	params.SetOrganizationCanonical(org)
 
@@ -48,7 +47,6 @@ func (m *middleware) CreateCredential(org, name, cType string, rawCred *models.C
 }
 
 func (m *middleware) UpdateCredential(org, name, cType string, rawCred *models.CredentialRaw, path, can, description string) (*models.Credential, error) {
-
 	params := organization_credentials.NewUpdateCredentialParams()
 	params.SetOrganizationCanonical(org)
 	params.SetCredentialCanonical(can)
@@ -86,7 +84,6 @@ func (m *middleware) UpdateCredential(org, name, cType string, rawCred *models.C
 }
 
 func (m *middleware) GetCredential(org, cred string) (*models.Credential, error) {
-
 	params := organization_credentials.NewGetCredentialParams()
 	params.SetOrganizationCanonical(org)
 	params.SetCredentialCanonical(cred)
@@ -103,7 +100,6 @@ func (m *middleware) GetCredential(org, cred string) (*models.Credential, error)
 }
 
 func (m *middleware) DeleteCredential(org, cred string) error {
-
 	params := organization_credentials.NewDeleteCredentialParams()
 	params.SetOrganizationCanonical(org)
 	params.SetCredentialCanonical(cred)
@@ -117,7 +113,6 @@ func (m *middleware) DeleteCredential(org, cred string) error {
 }
 
 func (m *middleware) ListCredentials(org, cType string) ([]*models.CredentialSimple, error) {
-
 	params := organization_credentials.NewListCredentialsParams()
 	params.SetOrganizationCanonical(org)
 


### PR DESCRIPTION
- **fix: don't fill SF value if null**
- **fix: remove default flag on get-env and use them.**
- **fix: use defaults on create-env/update-env**
- **fix: find the correct use case for env configuration**
- **fix: fix issue with key val flag strings**
- **fix: fix cli flags related tests**
- **misc: update cli docs**
- **misc: update version**
- **chore: add changelog**
- **zajdhal**
