### PR TITLE
feat(middleware): implement LHS filters on all List routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,42 +1,46 @@
 # AGENTS.md
 
-This file mirrors `CLAUDE.md` for LLM agents that use the AGENTS.md convention (e.g., OpenAI Codex, Gemini Code Assist). Keep in sync with `CLAUDE.md` when updating either file.
+This file mirrors `CLAUDE.md` for LLM agents that use the AGENTS.md convention. Keep in sync when updating either file.
 
 ---
+
+# CLAUDE.md
+
+This file is auto-loaded by Claude Code on every invocation. See also `AGENTS.md` (kept identical, for non-Claude LLM agents).
 
 ## Commands
 
 ```bash
 # Build
-make build # build all platform binaries
-go build -o cy . # quick local build
+make build                  # build all platform binaries
+go build -o cy .            # quick local build
 
 # Test (requires local backend)
-make be-start # start backend via docker compose
-go test ./... # run all tests
-make test # same
-make be-stop # stop backend
+make be-reset               # start backend via docker compose
+go test ./...               # run all tests
+make test                   # same
+make be-stop                # stop backend
 
 # Run a specific test
 go test ./e2e/... -run TestProjects
 go test ./cmd/cycloid/middleware/... -run TestGetProject
 
 # Lint & format
-make lint # golangci-lint + shellcheck
-make format # gci + goimports + shfmt
+make lint                   # golangci-lint + shellcheck
+make format                 # gci + goimports + shfmt
 
 # Client regeneration (when swagger.yaml changes)
-make client-generate # regenerates ./client/ from swagger.yaml
+make client-generate        # regenerates ./client/ from swagger.yaml
 
 # Changelog
-make new-changelog-entry # add unreleased changelog entry (uses changie via docker)
+make new-changelog-entry    # add unreleased changelog entry (uses changie via docker)
 ```
 
 ## Architecture
 
 ```
-cmd/cycloid/<feature>/*.go → cmd/cycloid/middleware/ → GenericRequest()
- (cobra commands) (Middleware interface) (generic_client.go)
+cmd/cycloid/<feature>/*.go  →  cmd/cycloid/middleware/  →  GenericRequest()
+     (cobra commands)              (Middleware interface)      (generic_client.go)
 ```
 
 ### Key packages
@@ -70,20 +74,61 @@ These are invariants that LLM agents and new contributors must not violate:
 ```go
 // Standard middleware method pattern:
 func (m *middleware) GetProject(org, project string) (*models.Project, *http.Response, error) {
- var result *models.Project
- resp, err := m.GenericRequest(Request{
- Method: "GET",
- Organization: &org,
- Route: []string{"organizations", org, "projects", project},
- }, &result)
- if err != nil {
- return nil, resp, err
- }
- return result, resp, nil
+    var result *models.Project
+    resp, err := m.GenericRequest(Request{
+        Method:       "GET",
+        Organization: &org,
+        Route:        []string{"organizations", org, "projects", project},
+    }, &result)
+    if err != nil {
+        return nil, resp, err
+    }
+    return result, resp, nil
 }
 ```
 
-`Request` fields: `Method`, `Organization` (*string, for auth), `NoAuth` (bool), `Route` ([]string), `Query` (struct with `url` tags), `Headers` (map), `Accept` (*string), `Body` (any, JSON-marshalled).
+`Request` fields: `Method`, `Organization` (*string, for auth), `NoAuth` (bool), `Route` ([]string), `Query` (struct with `url` tags), `LHSFilters` ([]LHSFilter, see below), `Headers` (map), `Accept` (*string), `Body` (any, JSON-marshalled).
+
+## LHS filters
+
+The Cycloid API supports LHS bracket filters on `List` routes: `attribute[condition]=value`. The condition is typically `eq`, `rlike`, `gt`, `lt`, etc.
+
+**Rule: all new `List` middleware methods must accept `filters ...LHSFilter` as their last parameter.**
+
+`LHSFilter` is defined in `cmd/cycloid/middleware/lhs_filter.go`:
+
+```go
+type LHSFilter struct {
+    Attribute string
+    Condition string
+    Value     string
+}
+```
+
+Pass filters via the `LHSFilters` field of `Request`. Brackets are kept literal (not percent-encoded) so the API receives `name[eq]=my-project`, not `name%5Beq%5D=my-project`. Regex metacharacters in values (`?`, `*`, `+`, etc.) are also preserved.
+
+```go
+// Example: list projects filtered by name prefix
+func (m *middleware) ListProjects(org string, filters ...LHSFilter) ([]*models.Project, *http.Response, error) {
+    var result []*models.Project
+    resp, err := m.GenericRequest(Request{
+        Method:       "GET",
+        Organization: &org,
+        Route:        []string{"organizations", org, "projects"},
+        LHSFilters:   filters,
+    }, &result)
+    ...
+}
+
+// Caller usage:
+projects, _, err := m.ListProjects(org, middleware.LHSFilter{
+    Attribute: "name",
+    Condition: "rlike",
+    Value:     "proj.*",
+})
+```
+
+Offline (no-backend) unit tests for LHS filter encoding live in `cmd/cycloid/middleware/offline/lhs_filter_test.go`.
 
 ### Return type conventions
 
@@ -99,28 +144,28 @@ Always return the `*http.Response` so callers can inspect status codes. Assign `
 
 ```go
 func getProject(cmd *cobra.Command, args []string) error {
- // Step 1: ALL flags first
- org, err := cyargs.GetOrg(cmd)
- if err != nil { return err }
- project, err := cyargs.GetProject(cmd)
- if err != nil { return err }
- output, err := cmd.Flags().GetString("output")
- if err != nil { return errors.Wrap(err, "unable to get output flag") }
+    // Step 1: ALL flags first
+    org, err := cyargs.GetOrg(cmd)
+    if err != nil { return err }
+    project, err := cyargs.GetProject(cmd)
+    if err != nil { return err }
+    output, err := cmd.Flags().GetString("output")
+    if err != nil { return errors.Wrap(err, "unable to get output flag") }
 
- // Step 2: printer
- p, err := factory.GetPrinter(output)
- if err != nil { return errors.Wrap(err, "unable to get printer") }
+    // Step 2: printer
+    p, err := factory.GetPrinter(output)
+    if err != nil { return errors.Wrap(err, "unable to get printer") }
 
- // Step 3: API + middleware
- api := common.NewAPI()
- m := middleware.NewMiddleware(api)
+    // Step 3: API + middleware
+    api := common.NewAPI()
+    m := middleware.NewMiddleware(api)
 
- // Step 4: call + print
- result, _, err := m.GetProject(org, project)
- if err != nil {
- return printer.SmartPrint(p, nil, err, "unable to get project", printer.Options{}, cmd.OutOrStderr())
- }
- return printer.SmartPrint(p, result, nil, "", printer.Options{}, cmd.OutOrStdout())
+    // Step 4: call + print
+    result, _, err := m.GetProject(org, project)
+    if err != nil {
+        return printer.SmartPrint(p, nil, err, "unable to get project", printer.Options{}, cmd.OutOrStderr())
+    }
+    return printer.SmartPrint(p, result, nil, "", printer.Options{}, cmd.OutOrStdout())
 }
 ```
 
@@ -130,12 +175,12 @@ All shared flag definitions live in `internal/cyargs/`. Pattern:
 
 ```go
 func AddWidgetFlag(cmd *cobra.Command) {
- cmd.Flags().String("widget", "", "Widget canonical")
- _ = cmd.RegisterFlagCompletionFunc("widget", widgetCompletion)
+    cmd.Flags().String("widget", "", "Widget canonical")
+    _ = cmd.RegisterFlagCompletionFunc("widget", widgetCompletion)
 }
 
 func GetWidget(cmd *cobra.Command) (string, error) {
- return cmd.Flags().GetString("widget")
+    return cmd.Flags().GetString("widget")
 }
 ```
 
@@ -160,3 +205,47 @@ Register in the command constructor (`NewGetX()`), never inside `RunE`.
 - `@docs/adding-a-command.md` — full walkthrough with working example
 - `@docs/testing.md` — middleware + e2e test patterns, testcfg deep-dive
 - `@docs/middleware-refactor.md` — what changed and why, migration reference
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **cycloid-cli** (11055 symbols, 67195 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/cycloid-cli/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/cycloid-cli/clusters` | All functional areas |
+| `gitnexus://repo/cycloid-cli/processes` | All execution flows |
+| `gitnexus://repo/cycloid-cli/process/{name}` | Step-by-step execution trace |
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,48 @@ func (m *middleware) GetProject(org, project string) (*models.Project, *http.Res
 }
 ```
 
-`Request` fields: `Method`, `Organization` (*string, for auth), `NoAuth` (bool), `Route` ([]string), `Query` (struct with `url` tags), `Headers` (map), `Accept` (*string), `Body` (any, JSON-marshalled).
+`Request` fields: `Method`, `Organization` (*string, for auth), `NoAuth` (bool), `Route` ([]string), `Query` (struct with `url` tags), `LHSFilters` ([]LHSFilter, see below), `Headers` (map), `Accept` (*string), `Body` (any, JSON-marshalled).
+
+## LHS filters
+
+The Cycloid API supports LHS bracket filters on `List` routes: `attribute[condition]=value`. The condition is typically `eq`, `rlike`, `gt`, `lt`, etc.
+
+**Rule: all new `List` middleware methods must accept `filters ...LHSFilter` as their last parameter.**
+
+`LHSFilter` is defined in `cmd/cycloid/middleware/lhs_filter.go`:
+
+```go
+type LHSFilter struct {
+    Attribute string
+    Condition string
+    Value     string
+}
+```
+
+Pass filters via the `LHSFilters` field of `Request`. Brackets are kept literal (not percent-encoded) so the API receives `name[eq]=my-project`, not `name%5Beq%5D=my-project`. Regex metacharacters in values (`?`, `*`, `+`, etc.) are also preserved.
+
+```go
+// Example: list projects filtered by name prefix
+func (m *middleware) ListProjects(org string, filters ...LHSFilter) ([]*models.Project, *http.Response, error) {
+    var result []*models.Project
+    resp, err := m.GenericRequest(Request{
+        Method:       "GET",
+        Organization: &org,
+        Route:        []string{"organizations", org, "projects"},
+        LHSFilters:   filters,
+    }, &result)
+    ...
+}
+
+// Caller usage:
+projects, _, err := m.ListProjects(org, middleware.LHSFilter{
+    Attribute: "name",
+    Condition: "rlike",
+    Value:     "proj.*",
+})
+```
+
+Offline (no-backend) unit tests for LHS filter encoding live in `cmd/cycloid/middleware/offline/lhs_filter_test.go`.
 
 ### Return type conventions
 
@@ -158,3 +199,47 @@ Register in the command constructor (`NewGetX()`), never inside `RunE`.
 - `@docs/adding-a-command.md` — full walkthrough with working example
 - `@docs/testing.md` — middleware + e2e test patterns, testcfg deep-dive
 - `@docs/middleware-refactor.md` — what changed and why, migration reference
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **cycloid-cli** (11055 symbols, 67195 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/cycloid-cli/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/cycloid-cli/clusters` | All functional areas |
+| `gitnexus://repo/cycloid-cli/processes` | All execution flows |
+| `gitnexus://repo/cycloid-cli/process/{name}` | Step-by-step execution trace |
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/cmd/cycloid/middleware/catalog_repositories.go
+++ b/cmd/cycloid/middleware/catalog_repositories.go
@@ -8,6 +8,10 @@ import (
 	"github.com/cycloidio/cycloid-cli/client/models"
 )
 
+// ListCatalogRepositories lists catalog repositories for an organization.
+//
+// NOTE: the backend handler for this route does not call lhs.ParseQuery, so
+// LHS filters are accepted by the middleware but silently ignored server-side.
 func (m *middleware) ListCatalogRepositories(org string, filters ...LHSFilter) ([]*models.ServiceCatalogSource, *http.Response, error) {
 	var result []*models.ServiceCatalogSource
 	resp, err := m.GenericRequest(Request{

--- a/cmd/cycloid/middleware/catalog_repositories.go
+++ b/cmd/cycloid/middleware/catalog_repositories.go
@@ -8,12 +8,13 @@ import (
 	"github.com/cycloidio/cycloid-cli/client/models"
 )
 
-func (m *middleware) ListCatalogRepositories(org string) ([]*models.ServiceCatalogSource, *http.Response, error) {
+func (m *middleware) ListCatalogRepositories(org string, filters ...LHSFilter) ([]*models.ServiceCatalogSource, *http.Response, error) {
 	var result []*models.ServiceCatalogSource
 	resp, err := m.GenericRequest(Request{
 		Method:       "GET",
 		Organization: &org,
 		Route:        []string{"organizations", org, "service_catalog_sources"},
+		LHSFilters:   filters,
 	}, &result)
 	if err != nil {
 		return nil, resp, err

--- a/cmd/cycloid/middleware/config_repositories.go
+++ b/cmd/cycloid/middleware/config_repositories.go
@@ -6,12 +6,13 @@ import (
 	"github.com/cycloidio/cycloid-cli/client/models"
 )
 
-func (m *middleware) ListConfigRepositories(org string) ([]*models.ConfigRepository, *http.Response, error) {
+func (m *middleware) ListConfigRepositories(org string, filters ...LHSFilter) ([]*models.ConfigRepository, *http.Response, error) {
 	var result []*models.ConfigRepository
 	resp, err := m.GenericRequest(Request{
 		Method:       "GET",
 		Organization: &org,
 		Route:        []string{"organizations", org, "config_repositories"},
+		LHSFilters:   filters,
 	}, &result)
 	if err != nil {
 		return nil, resp, err

--- a/cmd/cycloid/middleware/config_repositories.go
+++ b/cmd/cycloid/middleware/config_repositories.go
@@ -6,6 +6,10 @@ import (
 	"github.com/cycloidio/cycloid-cli/client/models"
 )
 
+// ListConfigRepositories lists config repositories for an organization.
+//
+// NOTE: the backend handler for this route does not call lhs.ParseQuery, so
+// LHS filters are accepted by the middleware but silently ignored server-side.
 func (m *middleware) ListConfigRepositories(org string, filters ...LHSFilter) ([]*models.ConfigRepository, *http.Response, error) {
 	var result []*models.ConfigRepository
 	resp, err := m.GenericRequest(Request{

--- a/cmd/cycloid/middleware/credentials.go
+++ b/cmd/cycloid/middleware/credentials.go
@@ -86,7 +86,7 @@ func (m *middleware) DeleteCredential(org, credential string) (*http.Response, e
 	return resp, err
 }
 
-func (m *middleware) ListCredentials(org, credentialType string) ([]*models.CredentialSimple, *http.Response, error) {
+func (m *middleware) ListCredentials(org, credentialType string, filters ...LHSFilter) ([]*models.CredentialSimple, *http.Response, error) {
 	// Explicit pagination matches swagger defaults (page_size 1000) so callers such as
 	// `credential create --update` do not miss an existing credential on backends that
 	// use a smaller default page size.
@@ -104,6 +104,7 @@ func (m *middleware) ListCredentials(org, credentialType string) ([]*models.Cred
 		Organization: &org,
 		Route:        []string{"organizations", org, "credentials"},
 		Query:        query,
+		LHSFilters:   filters,
 	}, &result)
 	if err != nil {
 		return nil, resp, err

--- a/cmd/cycloid/middleware/credentials.go
+++ b/cmd/cycloid/middleware/credentials.go
@@ -86,6 +86,10 @@ func (m *middleware) DeleteCredential(org, credential string) (*http.Response, e
 	return resp, err
 }
 
+// ListCredentials lists credentials for an organization.
+//
+// NOTE: the backend handler for this route does not call lhs.ParseQuery, so
+// LHS filters are accepted by the middleware but silently ignored server-side.
 func (m *middleware) ListCredentials(org, credentialType string, filters ...LHSFilter) ([]*models.CredentialSimple, *http.Response, error) {
 	// Explicit pagination matches swagger defaults (page_size 1000) so callers such as
 	// `credential create --update` do not miss an existing credential on backends that

--- a/cmd/cycloid/middleware/generic_client.go
+++ b/cmd/cycloid/middleware/generic_client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/spf13/viper"
@@ -30,13 +31,22 @@ func (m *middleware) GenericRequest(req Request, response any) (*http.Response, 
 	routeParts = append(routeParts, req.Route...)
 	baseURL.Path = path.Join(routeParts...)
 
-	// Encode query parameters
+	// Encode query parameters; LHS filters use raw encoding to preserve literal brackets.
+	var rawQueryParts []string
 	if req.Query != nil {
 		qv, err := encodeQuery(req.Query)
 		if err != nil {
 			return nil, fmt.Errorf("failed to encode query params: %w", err)
 		}
-		baseURL.RawQuery = qv.Encode()
+		if encoded := qv.Encode(); encoded != "" {
+			rawQueryParts = append(rawQueryParts, encoded)
+		}
+	}
+	if len(req.LHSFilters) > 0 {
+		rawQueryParts = append(rawQueryParts, buildLHSFilterQuery(req.LHSFilters))
+	}
+	if len(rawQueryParts) > 0 {
+		baseURL.RawQuery = strings.Join(rawQueryParts, "&")
 	}
 
 	// Marshal body

--- a/cmd/cycloid/middleware/http_client.go
+++ b/cmd/cycloid/middleware/http_client.go
@@ -33,13 +33,14 @@ type StackUseCase struct {
 // Request represents an HTTP request to the Cycloid API.
 type Request struct {
 	Method       string
-	Organization *string  // used for auth token lookup
-	NoAuth       bool     // disables auth header
-	Route        []string // joined onto base URL: ["organizations", org, "projects"]
-	Query        any      // url.Values or struct with `url` tags
+	Organization *string     // used for auth token lookup
+	NoAuth       bool        // disables auth header
+	Route        []string    // joined onto base URL: ["organizations", org, "projects"]
+	Query        any         // url.Values or struct with `url` tags
+	LHSFilters   []LHSFilter // LHS bracket filters: encoded as attribute[condition]=value with literal brackets
 	Headers      map[string]string
 	Accept       *string // overrides default Accept header
-	Body         any     // JSON-marshalled when non-nil
+	Body         any     // JSON-marshaled when non-nil
 }
 
 // APIResponseError is returned when the API returns a non-2xx response.

--- a/cmd/cycloid/middleware/http_client.go
+++ b/cmd/cycloid/middleware/http_client.go
@@ -21,6 +21,18 @@ type StackVersion struct {
 	Usage      *int64  `json:"usage"`
 }
 
+// InventoryOutput is the local representation of a terraform state output.
+// The model is not yet generated in the swagger client.
+type InventoryOutput struct {
+	ID          uint32      `json:"id"`
+	Key         string      `json:"key"`
+	Value       interface{} `json:"value,omitempty"`
+	Type        interface{} `json:"type,omitempty"`
+	Description string      `json:"description,omitempty"`
+	Sensitive   bool        `json:"sensitive,omitempty"`
+	Pinned      bool        `json:"pinned,omitempty"`
+}
+
 // StackUseCase is the local representation of a stack use case.
 // The model was removed from the generated swagger client.
 type StackUseCase struct {

--- a/cmd/cycloid/middleware/inventory.go
+++ b/cmd/cycloid/middleware/inventory.go
@@ -1,0 +1,84 @@
+package middleware
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/cycloidio/cycloid-cli/client/models"
+)
+
+// ListInventoryResources lists inventory resources for an organization.
+//
+// Supported LHS filter attributes:
+//   - resources_provider, resources_type, resources_name (display_name), resources_module,
+//     resources_mode, resources_label — resource-level fields
+//   - project_canonical, environment_canonical, component_canonical — via linked TF state
+//   - service_catalog_canonical, service_catalog_ref — via linked component
+//   - organization_canonical — organization scope
+//
+// Any unknown attribute key is treated as a JSON path filter against sr.attributes
+// and sr.custom_attributes (e.g. "tags.env[eq]=prod").
+func (m *middleware) ListInventoryResources(org string, filters ...LHSFilter) ([]*models.InventoryResource, *http.Response, error) {
+	var result []*models.InventoryResource
+	resp, err := m.GenericRequest(Request{
+		Method:       "GET",
+		Organization: &org,
+		Route:        []string{"organizations", org, "inventory"},
+		LHSFilters:   filters,
+	}, &result)
+	if err != nil {
+		return nil, resp, err
+	}
+	return result, resp, nil
+}
+
+// ListInventoryOutputs lists terraform state outputs for an organization.
+//
+// Supported LHS filter attributes:
+//   - output_key — output key name
+//   - output_type — output type filter
+//   - output_is_pinned — boolean, "true" or "false"
+//   - project_canonical, environment_canonical, component_canonical — via linked TF state
+//   - service_catalog_canonical — via linked component
+//   - organization_canonical — organization scope
+//
+// Any unknown attribute key is treated as a JSON path filter against ou.value
+// (e.g. "instance_ip[eq]=1.2.3.4").
+func (m *middleware) ListInventoryOutputs(org string, filters ...LHSFilter) ([]*InventoryOutput, *http.Response, error) {
+	var result []*InventoryOutput
+	resp, err := m.GenericRequest(Request{
+		Method:       "GET",
+		Organization: &org,
+		Route:        []string{"organizations", org, "inventory", "outputs"},
+		LHSFilters:   filters,
+	}, &result)
+	if err != nil {
+		return nil, resp, err
+	}
+	return result, resp, nil
+}
+
+// CreateInventoryResource creates an inventory resource for an organization.
+func (m *middleware) CreateInventoryResource(org string, body *models.NewInventoryResource) (*models.InventoryResource, *http.Response, error) {
+	var result *models.InventoryResource
+	resp, err := m.GenericRequest(Request{
+		Method:       "POST",
+		Organization: &org,
+		Route:        []string{"organizations", org, "inventory", "resources"},
+		Body:         body,
+	}, &result)
+	if err != nil {
+		return nil, resp, err
+	}
+	return result, resp, nil
+}
+
+// DeleteInventoryResource deletes an inventory resource by ID.
+func (m *middleware) DeleteInventoryResource(org string, id uint32) (*http.Response, error) {
+	resp, err := m.GenericRequest(Request{
+		Method:       "DELETE",
+		Organization: &org,
+		Route:        []string{"organizations", org, "inventory", "resources", strconv.FormatUint(uint64(id), 10)},
+	}, nil)
+	return resp, err
+}

--- a/cmd/cycloid/middleware/lhs_filter.go
+++ b/cmd/cycloid/middleware/lhs_filter.go
@@ -1,0 +1,46 @@
+package middleware
+
+import (
+	"fmt"
+	"strings"
+)
+
+// LHSFilter represents a single LHS bracket filter: attribute[condition]=value.
+// Encoded as a raw query parameter with literal brackets so the API receives
+// exactly attribute[condition]=value (not attribute%5Bcondition%5D=value).
+type LHSFilter struct {
+	Attribute string
+	Condition string
+	Value     string
+}
+
+// buildLHSFilterQuery builds a raw query string for LHS bracket filter params.
+// Brackets are kept literal in keys; values use lhsEscapeValue to preserve
+// regex metacharacters while encoding structurally significant chars.
+func buildLHSFilterQuery(filters []LHSFilter) string {
+	parts := make([]string, 0, len(filters))
+	for _, f := range filters {
+		key := f.Attribute + "[" + f.Condition + "]"
+		parts = append(parts, key+"="+lhsEscapeValue(f.Value))
+	}
+	return strings.Join(parts, "&")
+}
+
+// lhsEscapeValue percent-encodes only characters that are structurally
+// significant in query strings (&, =, #, space, control chars), preserving
+// regex metacharacters such as ?, *, +, [, ], (, ), {, }, |, ^, $, \.
+func lhsEscapeValue(s string) string {
+	var buf strings.Builder
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c == '&' || c == '=' || c == '#' || c == ' ':
+			fmt.Fprintf(&buf, "%%%02X", c)
+		case c < 0x20 || c >= 0x7F:
+			fmt.Fprintf(&buf, "%%%02X", c)
+		default:
+			buf.WriteByte(c)
+		}
+	}
+	return buf.String()
+}

--- a/cmd/cycloid/middleware/lhs_filter_discovery_test.go
+++ b/cmd/cycloid/middleware/lhs_filter_discovery_test.go
@@ -1,0 +1,301 @@
+package middleware_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cycloidio/cycloid-cli/client/models"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/testcfg"
+)
+
+// TestLHSFilterDiscovery verifies which attributes the backend accepts as LHS
+// filters on each List route that supports them. Field names follow the
+// backend's filtersMappings convention: <table_alias>_<column>.
+//
+// Routes confirmed to NOT support LHS filters (backend handler does not call
+// lhs.ParseQuery): ListTeamMembers, ListRoles, ListCredentials,
+// ListCatalogRepositories, ListConfigRepositories, ListStackVersions,
+// ListStackUseCases.
+//
+// A subtest failure means the attribute is not supported for that route.
+// Results inform the godoc on each List* middleware method.
+func TestLHSFilterDiscovery(t *testing.T) {
+	m := config.Middleware
+	org := config.Org
+
+	t.Run("Projects", func(t *testing.T) {
+		projA := testcfg.RandomCanonical("lhs-disc-a")
+		projB := testcfg.RandomCanonical("lhs-disc-b")
+		nameA := "LHS Discovery Alpha " + projA
+		nameB := "LHS Discovery Beta " + projB
+		configRepo := *config.ConfigRepo.Canonical
+
+		_, _, err := m.CreateProject(org, nameA, projA, "desc a", configRepo, "", "", "default", "world")
+		require.NoError(t, err, "setup: create projA")
+		defer func() { _, _ = m.DeleteProject(org, projA) }()
+
+		_, _, err = m.CreateProject(org, nameB, projB, "desc b", configRepo, "", "", "default", "world")
+		require.NoError(t, err, "setup: create projB")
+		defer func() { _, _ = m.DeleteProject(org, projB) }()
+
+		t.Run("project_canonical[eq]", func(t *testing.T) {
+			results, _, err := m.ListProjects(org, middleware.LHSFilter{Attribute: "project_canonical", Condition: "eq", Value: projA})
+			require.NoError(t, err)
+			require.NotEmpty(t, results)
+			for _, p := range results {
+				assert.Equal(t, projA, *p.Canonical)
+			}
+		})
+
+		t.Run("project_name[eq]", func(t *testing.T) {
+			results, _, err := m.ListProjects(org, middleware.LHSFilter{Attribute: "project_name", Condition: "eq", Value: nameA})
+			require.NoError(t, err)
+			require.NotEmpty(t, results)
+			for _, p := range results {
+				assert.Equal(t, nameA, *p.Name)
+			}
+		})
+
+		t.Run("project_name[rlike]", func(t *testing.T) {
+			results, _, err := m.ListProjects(org, middleware.LHSFilter{Attribute: "project_name", Condition: "rlike", Value: "LHS Discovery .*"})
+			require.NoError(t, err)
+			var found int
+			for _, p := range results {
+				if *p.Canonical == projA || *p.Canonical == projB {
+					found++
+				}
+			}
+			assert.Equal(t, 2, found, "rlike must match both lhs-disc projects")
+		})
+	})
+
+	t.Run("Stacks", func(t *testing.T) {
+		// Stack creation requires complex catalog-repo setup — rely on the
+		// test stack seeded by testcfg.
+		testCanonical := "stack-e2e-stackforms"
+		testRef := org + ":" + testCanonical
+
+		all, _, err := m.ListStacks(org)
+		require.NoError(t, err)
+		require.NotEmpty(t, all, "test stacks must exist")
+
+		t.Run("service_catalog_ref[eq]", func(t *testing.T) {
+			results, _, err := m.ListStacks(org, middleware.LHSFilter{Attribute: "service_catalog_ref", Condition: "eq", Value: testRef})
+			require.NoError(t, err)
+			require.NotEmpty(t, results)
+			for _, s := range results {
+				assert.Equal(t, testRef, *s.Ref)
+			}
+			assert.Less(t, len(results), len(all), "filtered must be smaller than full list")
+		})
+
+		t.Run("service_catalog_visibility[eq]", func(t *testing.T) {
+			// valid values: local, shared, hidden (handled with custom logic in backend)
+			results, _, err := m.ListStacks(org, middleware.LHSFilter{Attribute: "service_catalog_visibility", Condition: "eq", Value: "local"})
+			require.NoError(t, err)
+			for _, s := range results {
+				assert.Equal(t, "local", *s.Visibility)
+			}
+		})
+
+		t.Run("service_catalog_blueprint[eq]", func(t *testing.T) {
+			results, _, err := m.ListStacks(org, middleware.LHSFilter{Attribute: "service_catalog_blueprint", Condition: "eq", Value: "false"})
+			require.NoError(t, err)
+			assert.NotNil(t, results)
+		})
+	})
+
+	t.Run("Components", func(t *testing.T) {
+		knownCanonical := *config.Component.Canonical
+		proj := *config.Project.Canonical
+		env := *config.Environment.Canonical
+
+		all, _, err := m.ListComponents(org, proj, env)
+		require.NoError(t, err)
+		require.NotEmpty(t, all, "test component must exist")
+
+		t.Run("component_canonical[eq]", func(t *testing.T) {
+			results, _, err := m.ListComponents(org, proj, env, middleware.LHSFilter{Attribute: "component_canonical", Condition: "eq", Value: knownCanonical})
+			require.NoError(t, err)
+			require.NotEmpty(t, results)
+			for _, c := range results {
+				assert.Equal(t, knownCanonical, *c.Canonical)
+			}
+		})
+
+		t.Run("service_catalog_ref[eq]", func(t *testing.T) {
+			stackRef := org + ":stack-e2e-stackforms"
+			results, _, err := m.ListComponents(org, proj, env, middleware.LHSFilter{Attribute: "service_catalog_ref", Condition: "eq", Value: stackRef})
+			require.NoError(t, err)
+			assert.NotNil(t, results)
+		})
+
+		t.Run("environment_canonical[eq]", func(t *testing.T) {
+			results, _, err := m.ListComponents(org, proj, env, middleware.LHSFilter{Attribute: "environment_canonical", Condition: "eq", Value: env})
+			require.NoError(t, err)
+			assert.NotEmpty(t, results)
+		})
+	})
+
+	t.Run("Members", func(t *testing.T) {
+		// List all members to get a known canonical for filtering
+		all, _, err := m.ListMembers(org)
+		require.NoError(t, err)
+		require.NotEmpty(t, all, "org must have at least one member")
+		knownCanonical := all[0].Username
+
+		t.Run("user_canonical[eq]", func(t *testing.T) {
+			results, _, err := m.ListMembers(org, middleware.LHSFilter{Attribute: "user_canonical", Condition: "eq", Value: knownCanonical})
+			require.NoError(t, err)
+			require.NotEmpty(t, results)
+			for _, member := range results {
+				assert.Equal(t, knownCanonical, member.Username)
+			}
+		})
+
+		t.Run("invitation_state[eq]", func(t *testing.T) {
+			// accepted is the normal state for active members
+			results, _, err := m.ListMembers(org, middleware.LHSFilter{Attribute: "invitation_state", Condition: "eq", Value: "accepted"})
+			require.NoError(t, err)
+			assert.NotNil(t, results)
+		})
+	})
+
+	t.Run("Teams", func(t *testing.T) {
+		// List all teams; test env may or may not have teams, so we just verify
+		// the filter is accepted without error. If teams exist, verify filtering.
+		all, _, err := m.ListTeams(org, nil, nil, nil, nil)
+		require.NoError(t, err)
+
+		t.Run("team_canonical[eq]", func(t *testing.T) {
+			if len(all) == 0 {
+				t.Skip("no teams in test org")
+			}
+			knownCanonical := *all[0].Canonical
+			results, _, err2 := m.ListTeams(org, nil, nil, nil, nil, middleware.LHSFilter{Attribute: "team_canonical", Condition: "eq", Value: knownCanonical})
+			require.NoError(t, err2)
+			for _, team := range results {
+				assert.Equal(t, knownCanonical, *team.Canonical)
+			}
+		})
+
+		t.Run("team_name[rlike]", func(t *testing.T) {
+			if len(all) == 0 {
+				t.Skip("no teams in test org")
+			}
+			_, _, err2 := m.ListTeams(org, nil, nil, nil, nil, middleware.LHSFilter{Attribute: "team_name", Condition: "rlike", Value: ".*"})
+			require.NoError(t, err2)
+		})
+	})
+
+	t.Run("InventoryResources", func(t *testing.T) {
+		label := "lhs-disc-label"
+		provider := "custom_resources"
+		resType := "custom_instance"
+		nameA := testcfg.RandomCanonical("lhs-res-a")
+		nameB := testcfg.RandomCanonical("lhs-res-b")
+
+		resA, _, err := m.CreateInventoryResource(org, &models.NewInventoryResource{
+			Label:    &label,
+			Name:     &nameA,
+			Provider: &provider,
+			Type:     &resType,
+		})
+		require.NoError(t, err, "setup: create inventory resource A")
+		defer func() { _, _ = m.DeleteInventoryResource(org, resA.ID) }()
+
+		resB, _, err := m.CreateInventoryResource(org, &models.NewInventoryResource{
+			Label:    &label,
+			Name:     &nameB,
+			Provider: &provider,
+			Type:     &resType,
+		})
+		require.NoError(t, err, "setup: create inventory resource B")
+		defer func() { _, _ = m.DeleteInventoryResource(org, resB.ID) }()
+
+		t.Run("resources_provider[eq]", func(t *testing.T) {
+			results, _, err := m.ListInventoryResources(org, middleware.LHSFilter{Attribute: "resources_provider", Condition: "eq", Value: provider})
+			require.NoError(t, err)
+			for _, r := range results {
+				assert.Equal(t, provider, *r.Provider)
+			}
+		})
+
+		t.Run("resources_type[eq]", func(t *testing.T) {
+			results, _, err := m.ListInventoryResources(org, middleware.LHSFilter{Attribute: "resources_type", Condition: "eq", Value: resType})
+			require.NoError(t, err)
+			for _, r := range results {
+				assert.Equal(t, resType, *r.Type)
+			}
+		})
+
+		t.Run("resources_label[eq]", func(t *testing.T) {
+			results, _, err := m.ListInventoryResources(org, middleware.LHSFilter{Attribute: "resources_label", Condition: "eq", Value: label})
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, len(results), 2)
+			for _, r := range results {
+				assert.Equal(t, label, r.Label)
+			}
+		})
+
+		t.Run("resources_name[rlike]", func(t *testing.T) {
+			results, _, err := m.ListInventoryResources(org, middleware.LHSFilter{Attribute: "resources_name", Condition: "rlike", Value: "lhs-res-.*"})
+			require.NoError(t, err)
+			var found int
+			for _, r := range results {
+				if *r.Name == nameA || *r.Name == nameB {
+					found++
+				}
+			}
+			assert.Equal(t, 2, found, "rlike must match both lhs-disc inventory resources")
+		})
+	})
+
+	t.Run("InventoryOutputs", func(t *testing.T) {
+		// Outputs come from TF states — cannot be created directly. We verify
+		// the filter attributes are accepted by the route without error.
+		t.Run("output_key[eq] accepted", func(t *testing.T) {
+			_, _, err := m.ListInventoryOutputs(org, middleware.LHSFilter{Attribute: "output_key", Condition: "eq", Value: "nonexistent"})
+			require.NoError(t, err)
+		})
+
+		t.Run("output_is_pinned[eq] accepted", func(t *testing.T) {
+			_, _, err := m.ListInventoryOutputs(org, middleware.LHSFilter{Attribute: "output_is_pinned", Condition: "eq", Value: "false"})
+			require.NoError(t, err)
+		})
+
+		t.Run("output_type[eq] accepted", func(t *testing.T) {
+			_, _, err := m.ListInventoryOutputs(org, middleware.LHSFilter{Attribute: "output_type", Condition: "eq", Value: "string"})
+			require.NoError(t, err)
+		})
+
+		t.Run("project_canonical[eq] accepted", func(t *testing.T) {
+			_, _, err := m.ListInventoryOutputs(org, middleware.LHSFilter{Attribute: "project_canonical", Condition: "eq", Value: "nonexistent"})
+			require.NoError(t, err)
+		})
+	})
+
+	t.Run("APIKeys", func(t *testing.T) {
+		all, _, err := m.ListAPIKeys(org)
+		require.NoError(t, err)
+
+		t.Run("organization_canonical[eq]", func(t *testing.T) {
+			// organization_canonical is always org in this context
+			results, _, err2 := m.ListAPIKeys(org, middleware.LHSFilter{Attribute: "organization_canonical", Condition: "eq", Value: org})
+			require.NoError(t, err2)
+			assert.Equal(t, len(all), len(results), "filtering by org canonical should return same count")
+		})
+
+		t.Run("user_canonical[eq]", func(t *testing.T) {
+			if len(all) == 0 {
+				t.Skip("no API keys in test org")
+			}
+			// Verify filter is accepted; nonexistent user returns empty not error
+			_, _, err2 := m.ListAPIKeys(org, middleware.LHSFilter{Attribute: "user_canonical", Condition: "eq", Value: "nonexistent"})
+			require.NoError(t, err2)
+		})
+	})
+}

--- a/cmd/cycloid/middleware/middleware.go
+++ b/cmd/cycloid/middleware/middleware.go
@@ -25,7 +25,7 @@ type Middleware interface {
 
 	// catalog_repositories
 	CreateCatalogRepository(org, name, url, branch, cred, visibility, teamCanonical string) (*models.ServiceCatalogSource, *http.Response, error)
-	ListCatalogRepositories(org string) ([]*models.ServiceCatalogSource, *http.Response, error)
+	ListCatalogRepositories(org string, filters ...LHSFilter) ([]*models.ServiceCatalogSource, *http.Response, error)
 	GetCatalogRepository(org, catalogRepo string) (*models.ServiceCatalogSource, *http.Response, error)
 	DeleteCatalogRepository(org, catalogRepo string) (*http.Response, error)
 	UpdateCatalogRepository(org, catalogRepo string, name, url, branch, cred string, visibility *string) (*models.ServiceCatalogSource, *http.Response, error)
@@ -34,17 +34,17 @@ type Middleware interface {
 	CreateConfigRepository(org, name, canonical, url, branch, cred string, setDefault bool) (*models.ConfigRepository, *http.Response, error)
 	DeleteConfigRepository(org, configRepo string) (*http.Response, error)
 	GetConfigRepository(org, configRepo string) (*models.ConfigRepository, *http.Response, error)
-	ListConfigRepositories(org string) ([]*models.ConfigRepository, *http.Response, error)
+	ListConfigRepositories(org string, filters ...LHSFilter) ([]*models.ConfigRepository, *http.Response, error)
 	UpdateConfigRepository(org, configRepo, cred, name, url, branch string, setDefault bool) (*models.ConfigRepository, *http.Response, error)
 
 	// stacks (service_catalogs)
 	GetStack(org, ref string) (*models.ServiceCatalog, *http.Response, error)
 	UpdateStack(org, ref, teamCanonical string, visibility *string) (*models.ServiceCatalog, *http.Response, error)
-	ListStacks(org string) ([]*models.ServiceCatalog, *http.Response, error)
-	ListStackUseCases(org, ref, versionTag, versionBranch, versionCommitHash string) ([]*StackUseCase, *http.Response, error)
-	ListStackVersions(org, ref string) ([]*StackVersion, *http.Response, error)
+	ListStacks(org string, filters ...LHSFilter) ([]*models.ServiceCatalog, *http.Response, error)
+	ListStackUseCases(org, ref, versionTag, versionBranch, versionCommitHash string, filters ...LHSFilter) ([]*StackUseCase, *http.Response, error)
+	ListStackVersions(org, ref string, filters ...LHSFilter) ([]*StackVersion, *http.Response, error)
 	ResolveStackVersion(org, ref, stackVersion string) (uint32, string, error)
-	ListBlueprints(org string) ([]*models.ServiceCatalog, *http.Response, error)
+	ListBlueprints(org string, filters ...LHSFilter) ([]*models.ServiceCatalog, *http.Response, error)
 	CreateStackFromBlueprint(org, blueprintRef, name, stack, catalogRepository, useCase string) (*models.ServiceCatalog, *http.Response, error)
 
 	// organization_credentials
@@ -52,7 +52,7 @@ type Middleware interface {
 	UpdateCredential(org, name, credentialType string, rawCred *models.CredentialRaw, path, canonical, description string) (*models.Credential, *http.Response, error)
 	DeleteCredential(org, credential string) (*http.Response, error)
 	GetCredential(org, credential string) (*models.Credential, *http.Response, error)
-	ListCredentials(org, credentialType string) ([]*models.CredentialSimple, *http.Response, error)
+	ListCredentials(org, credentialType string, filters ...LHSFilter) ([]*models.CredentialSimple, *http.Response, error)
 
 	// events
 	SendEvent(org, eventType, title, message, severity string, tags map[string]string, color string) (*http.Response, error)
@@ -70,19 +70,19 @@ type Middleware interface {
 	DeleteMember(org string, id uint32) (*http.Response, error)
 	GetMember(org string, id uint32) (*models.MemberOrg, *http.Response, error)
 	InviteMember(org, email, role string) (*models.MemberOrg, *http.Response, error)
-	ListMembers(org string) ([]*models.MemberOrg, *http.Response, error)
+	ListMembers(org string, filters ...LHSFilter) ([]*models.MemberOrg, *http.Response, error)
 	ListInvites(org string) ([]*models.MemberOrg, *http.Response, error)
 	UpdateMember(org string, id uint32, role string) (*models.MemberOrg, *http.Response, error)
 
 	// organization_teams
-	ListTeams(org string, teamNameFilter *string, createdAtFilter *uint64, memberIDFilter *uint32, orderBy *TeamOrderByParam) ([]*models.Team, *http.Response, error)
+	ListTeams(org string, teamNameFilter *string, createdAtFilter *uint64, memberIDFilter *uint32, orderBy *TeamOrderByParam, filters ...LHSFilter) ([]*models.Team, *http.Response, error)
 	GetTeam(org, team string) (*models.Team, *http.Response, error)
 	CreateTeam(org string, name, team, owner *string, roles []string) (*models.Team, *http.Response, error)
 	UpdateTeam(org string, name, team, owner *string, roles []string) (*models.Team, *http.Response, error)
 	DeleteTeam(org, team string) (*http.Response, error)
 
 	// organization_team_members
-	ListTeamMembers(org string, team string) ([]*models.MemberTeam, *http.Response, error)
+	ListTeamMembers(org string, team string, filters ...LHSFilter) ([]*models.MemberTeam, *http.Response, error)
 	GetTeamMember(org string, team string, memberID uint32) (*models.MemberTeam, *http.Response, error)
 	AssignMemberToTeam(org, team string, username, email *string) (*models.MemberTeam, *http.Response, error)
 	UnAssignMemberFromTeam(org, team string, memberID uint32) (*http.Response, error)
@@ -146,8 +146,8 @@ type Middleware interface {
 	UpdateProject(org, projectName, project, description, configRepository, owner, team, color, icon, cloudProvider string) (*models.Project, *http.Response, error)
 	DeleteProject(org, project string) (*http.Response, error)
 	GetProject(org string, project string) (*models.Project, *http.Response, error)
-	ListProjects(org string) ([]*models.Project, *http.Response, error)
-	ListProjectsEnv(org, project string) ([]*models.Environment, *http.Response, error)
+	ListProjects(org string, filters ...LHSFilter) ([]*models.Project, *http.Response, error)
+	ListProjectsEnv(org, project string, filters ...LHSFilter) ([]*models.Environment, *http.Response, error)
 
 	// Env
 	GetEnv(org, project, env string) (*models.Environment, *http.Response, error)
@@ -157,7 +157,7 @@ type Middleware interface {
 
 	// Component
 	CreateOrUpdateComponent(org, project, env, component, description, name, stackRef, versionTag, versionBranch, versionCommitHash, useCase, cloudProvider string, vars models.FormVariables) (*models.Component, *http.Response, error)
-	ListComponents(org, project, env string) ([]*models.Component, *http.Response, error)
+	ListComponents(org, project, env string, filters ...LHSFilter) ([]*models.Component, *http.Response, error)
 	GetComponent(org, project, env, component string) (*models.Component, *http.Response, error)
 	MigrateComponent(org, project, env, component, targetProject, targetEnv, newCanonical, newName string) (*models.Component, *http.Response, error)
 	DeleteComponent(org, project, env, component string) (*http.Response, error)
@@ -166,12 +166,12 @@ type Middleware interface {
 
 	DeleteRole(org, role string) (*http.Response, error)
 	GetRole(org, role string) (*models.Role, *http.Response, error)
-	ListRoles(org string) ([]*models.Role, *http.Response, error)
+	ListRoles(org string, filters ...LHSFilter) ([]*models.Role, *http.Response, error)
 	CreateRole(org string, name, canonical, description *string, rules []*models.NewRule) (*models.NewRole, *http.Response, error)
 	UpdateRole(org, roleCanonical string, name, canonical, description *string, rules []*models.NewRule) (*models.Role, *http.Response, error)
 
 	// ApiKeys
-	ListAPIKeys(org string) ([]*models.APIKey, *http.Response, error)
+	ListAPIKeys(org string, filters ...LHSFilter) ([]*models.APIKey, *http.Response, error)
 	GetAPIKey(org, canonical string) (*models.APIKey, *http.Response, error)
 	CreateAPIKey(org, canonical, description, owner string, name *string, rules []*models.NewRule) (*models.APIKey, *http.Response, error)
 	DeleteAPIKey(org, canonical string) (*http.Response, error)

--- a/cmd/cycloid/middleware/middleware.go
+++ b/cmd/cycloid/middleware/middleware.go
@@ -170,6 +170,12 @@ type Middleware interface {
 	CreateRole(org string, name, canonical, description *string, rules []*models.NewRule) (*models.NewRole, *http.Response, error)
 	UpdateRole(org, roleCanonical string, name, canonical, description *string, rules []*models.NewRule) (*models.Role, *http.Response, error)
 
+	// inventory
+	ListInventoryResources(org string, filters ...LHSFilter) ([]*models.InventoryResource, *http.Response, error)
+	ListInventoryOutputs(org string, filters ...LHSFilter) ([]*InventoryOutput, *http.Response, error)
+	CreateInventoryResource(org string, body *models.NewInventoryResource) (*models.InventoryResource, *http.Response, error)
+	DeleteInventoryResource(org string, id uint32) (*http.Response, error)
+
 	// ApiKeys
 	ListAPIKeys(org string, filters ...LHSFilter) ([]*models.APIKey, *http.Response, error)
 	GetAPIKey(org, canonical string) (*models.APIKey, *http.Response, error)

--- a/cmd/cycloid/middleware/offline/lhs_filter_test.go
+++ b/cmd/cycloid/middleware/offline/lhs_filter_test.go
@@ -1,0 +1,138 @@
+package offline_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+)
+
+// captureRawQuery runs a GenericRequest with the given LHSFilters against a local
+// test server and returns the raw query string the server received.
+func captureRawQuery(t *testing.T, filters []middleware.LHSFilter) string {
+	t.Helper()
+	var captured string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	api := common.NewAPI(common.WithURL(srv.URL), common.WithToken("test-token"))
+	m := middleware.NewMiddleware(api)
+
+	var out []any
+	_, err := m.GenericRequest(middleware.Request{
+		Method:     http.MethodGet,
+		Route:      []string{"test"},
+		LHSFilters: filters,
+	}, &out)
+	require.NoError(t, err)
+	return captured
+}
+
+func TestLHSFilterBracketsNotEncoded(t *testing.T) {
+	raw := captureRawQuery(t, []middleware.LHSFilter{
+		{Attribute: "name", Condition: "eq", Value: "my-project"},
+	})
+	assert.Equal(t, "name[eq]=my-project", raw, "brackets must be literal, not percent-encoded")
+}
+
+func TestLHSFilterMultipleFilters(t *testing.T) {
+	raw := captureRawQuery(t, []middleware.LHSFilter{
+		{Attribute: "name", Condition: "eq", Value: "my-project"},
+		{Attribute: "canonical", Condition: "rlike", Value: "proj.*"},
+	})
+	assert.Equal(t, "name[eq]=my-project&canonical[rlike]=proj.*", raw)
+}
+
+func TestLHSFilterRegexMetacharsPreserved(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		wantValue string
+	}{
+		{"dot wildcard", "dg.growy", "dg.growy"},
+		{"question mark", "dg.?growy", "dg.?growy"},
+		{"star wildcard", "dg.*growy", "dg.*growy"},
+		{"plus quantifier", "dg.+growy", "dg.+growy"},
+		{"brackets", "[A-Z]+", "[A-Z]+"},
+		{"pipe alternation", "foo|bar", "foo|bar"},
+		{"caret anchor", "^foo", "^foo"},
+		{"dollar anchor", "foo$", "foo$"},
+		{"backslash escape", `foo\.bar`, `foo\.bar`},
+		{"parens groups", "(foo|bar)", "(foo|bar)"},
+		{"curly braces", "a{2,4}", "a{2,4}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := captureRawQuery(t, []middleware.LHSFilter{
+				{Attribute: "name", Condition: "rlike", Value: tt.value},
+			})
+			assert.Equal(t, "name[rlike]="+tt.wantValue, raw)
+		})
+	}
+}
+
+func TestLHSFilterStructuralCharsEncoded(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		wantValue string
+	}{
+		{"ampersand", "foo&bar", "foo%26bar"},
+		{"equals", "foo=bar", "foo%3Dbar"},
+		{"hash", "foo#bar", "foo%23bar"},
+		{"space", "foo bar", "foo%20bar"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := captureRawQuery(t, []middleware.LHSFilter{
+				{Attribute: "name", Condition: "eq", Value: tt.value},
+			})
+			assert.Equal(t, "name[eq]="+tt.wantValue, raw)
+		})
+	}
+}
+
+func TestLHSFilterCombinedWithRegularQuery(t *testing.T) {
+	var captured string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	api := common.NewAPI(common.WithURL(srv.URL), common.WithToken("test-token"))
+	m := middleware.NewMiddleware(api)
+
+	type queryParams struct {
+		PageSize int `url:"page_size"`
+	}
+
+	var out []any
+	_, err := m.GenericRequest(middleware.Request{
+		Method: http.MethodGet,
+		Route:  []string{"test"},
+		Query:  queryParams{PageSize: 100},
+		LHSFilters: []middleware.LHSFilter{
+			{Attribute: "name", Condition: "eq", Value: "my-project"},
+		},
+	}, &out)
+	require.NoError(t, err)
+
+	assert.Contains(t, captured, "page_size=100")
+	assert.Contains(t, captured, "name[eq]=my-project")
+}
+
+func TestLHSFilterEmpty(t *testing.T) {
+	raw := captureRawQuery(t, nil)
+	assert.Equal(t, "", raw, "no filters should produce no query string")
+}

--- a/cmd/cycloid/middleware/organization_api_key.go
+++ b/cmd/cycloid/middleware/organization_api_key.go
@@ -8,12 +8,13 @@ import (
 )
 
 // ListAPIKeys will request API to list generated API keys
-func (m *middleware) ListAPIKeys(org string) ([]*models.APIKey, *http.Response, error) {
+func (m *middleware) ListAPIKeys(org string, filters ...LHSFilter) ([]*models.APIKey, *http.Response, error) {
 	var result []*models.APIKey
 	resp, err := m.GenericRequest(Request{
 		Method:       "GET",
 		Organization: &org,
 		Route:        []string{"organizations", org, "api_keys"},
+		LHSFilters:   filters,
 	}, &result)
 	if err != nil {
 		return nil, resp, fmt.Errorf("unable to list API keys: %w", err)

--- a/cmd/cycloid/middleware/organization_api_key.go
+++ b/cmd/cycloid/middleware/organization_api_key.go
@@ -7,7 +7,9 @@ import (
 	"github.com/cycloidio/cycloid-cli/client/models"
 )
 
-// ListAPIKeys will request API to list generated API keys
+// ListAPIKeys lists API keys for an organization.
+//
+// Supported LHS filter attributes: organization_canonical, user_canonical.
 func (m *middleware) ListAPIKeys(org string, filters ...LHSFilter) ([]*models.APIKey, *http.Response, error) {
 	var result []*models.APIKey
 	resp, err := m.GenericRequest(Request{

--- a/cmd/cycloid/middleware/organization_components.go
+++ b/cmd/cycloid/middleware/organization_components.go
@@ -36,6 +36,11 @@ func (m *middleware) GetComponent(org, project, env, component string) (*models.
 	return result, resp, nil
 }
 
+// ListComponents lists components for a project environment.
+//
+// Supported LHS filter attributes: component_canonical, service_catalog_ref,
+// service_catalog_source_canonical, environment_canonical, project_canonical,
+// component_version_type, component_version_status, component_version_name.
 func (m *middleware) ListComponents(org, project, env string, filters ...LHSFilter) ([]*models.Component, *http.Response, error) {
 	var result []*models.Component
 	resp, err := m.GenericRequest(Request{

--- a/cmd/cycloid/middleware/organization_components.go
+++ b/cmd/cycloid/middleware/organization_components.go
@@ -36,12 +36,13 @@ func (m *middleware) GetComponent(org, project, env, component string) (*models.
 	return result, resp, nil
 }
 
-func (m *middleware) ListComponents(org, project, env string) ([]*models.Component, *http.Response, error) {
+func (m *middleware) ListComponents(org, project, env string, filters ...LHSFilter) ([]*models.Component, *http.Response, error) {
 	var result []*models.Component
 	resp, err := m.GenericRequest(Request{
 		Method:       "GET",
 		Organization: &org,
 		Route:        []string{"organizations", org, "projects", project, "environments", env, "components"},
+		LHSFilters:   filters,
 	}, &result)
 	if err != nil {
 		return nil, resp, err

--- a/cmd/cycloid/middleware/organization_members.go
+++ b/cmd/cycloid/middleware/organization_members.go
@@ -10,12 +10,13 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-func (m *middleware) ListMembers(org string) ([]*models.MemberOrg, *http.Response, error) {
+func (m *middleware) ListMembers(org string, filters ...LHSFilter) ([]*models.MemberOrg, *http.Response, error) {
 	var result []*models.MemberOrg
 	resp, err := m.GenericRequest(Request{
 		Method:       "GET",
 		Organization: &org,
 		Route:        []string{"organizations", org, "members"},
+		LHSFilters:   filters,
 	}, &result)
 	if err != nil {
 		return nil, resp, err

--- a/cmd/cycloid/middleware/organization_members.go
+++ b/cmd/cycloid/middleware/organization_members.go
@@ -10,6 +10,10 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
+// ListMembers lists organization members.
+//
+// Supported LHS filter attributes: user_canonical, user_full_name,
+// invitation_state, invitation_created_at, role_name.
 func (m *middleware) ListMembers(org string, filters ...LHSFilter) ([]*models.MemberOrg, *http.Response, error) {
 	var result []*models.MemberOrg
 	resp, err := m.GenericRequest(Request{

--- a/cmd/cycloid/middleware/organization_projects.go
+++ b/cmd/cycloid/middleware/organization_projects.go
@@ -7,12 +7,13 @@ import (
 	"github.com/cycloidio/cycloid-cli/client/models"
 )
 
-func (m *middleware) ListProjects(org string) ([]*models.Project, *http.Response, error) {
+func (m *middleware) ListProjects(org string, filters ...LHSFilter) ([]*models.Project, *http.Response, error) {
 	var result []*models.Project
 	resp, err := m.GenericRequest(Request{
 		Method:       "GET",
 		Organization: &org,
 		Route:        []string{"organizations", org, "projects"},
+		LHSFilters:   filters,
 	}, &result)
 	if err != nil {
 		return nil, resp, err
@@ -20,12 +21,13 @@ func (m *middleware) ListProjects(org string) ([]*models.Project, *http.Response
 	return result, resp, nil
 }
 
-func (m *middleware) ListProjectsEnv(org, project string) ([]*models.Environment, *http.Response, error) {
+func (m *middleware) ListProjectsEnv(org, project string, filters ...LHSFilter) ([]*models.Environment, *http.Response, error) {
 	var result []*models.Environment
 	resp, err := m.GenericRequest(Request{
 		Method:       "GET",
 		Organization: &org,
 		Route:        []string{"organizations", org, "projects", project, "environments"},
+		LHSFilters:   filters,
 	}, &result)
 	if err != nil {
 		return nil, resp, err

--- a/cmd/cycloid/middleware/organization_projects.go
+++ b/cmd/cycloid/middleware/organization_projects.go
@@ -7,6 +7,11 @@ import (
 	"github.com/cycloidio/cycloid-cli/client/models"
 )
 
+// ListProjects lists projects for an organization.
+//
+// Supported LHS filter attributes: project_canonical, project_name,
+// project_description, project_created_at, project_config_repository_canonical,
+// environment_canonical, user_canonical.
 func (m *middleware) ListProjects(org string, filters ...LHSFilter) ([]*models.Project, *http.Response, error) {
 	var result []*models.Project
 	resp, err := m.GenericRequest(Request{
@@ -21,6 +26,9 @@ func (m *middleware) ListProjects(org string, filters ...LHSFilter) ([]*models.P
 	return result, resp, nil
 }
 
+// ListProjectsEnv lists environments for a project.
+//
+// Supported LHS filter attributes: environment_canonical, environment_created_at.
 func (m *middleware) ListProjectsEnv(org, project string, filters ...LHSFilter) ([]*models.Environment, *http.Response, error) {
 	var result []*models.Environment
 	resp, err := m.GenericRequest(Request{

--- a/cmd/cycloid/middleware/organization_roles.go
+++ b/cmd/cycloid/middleware/organization_roles.go
@@ -8,12 +8,13 @@ import (
 	"github.com/cycloidio/cycloid-cli/internal/ptr"
 )
 
-func (m *middleware) ListRoles(org string) ([]*models.Role, *http.Response, error) {
+func (m *middleware) ListRoles(org string, filters ...LHSFilter) ([]*models.Role, *http.Response, error) {
 	var result []*models.Role
 	resp, err := m.GenericRequest(Request{
 		Method:       "GET",
 		Organization: &org,
 		Route:        []string{"organizations", org, "roles"},
+		LHSFilters:   filters,
 	}, &result)
 	if err != nil {
 		return nil, resp, err

--- a/cmd/cycloid/middleware/organization_roles.go
+++ b/cmd/cycloid/middleware/organization_roles.go
@@ -8,6 +8,10 @@ import (
 	"github.com/cycloidio/cycloid-cli/internal/ptr"
 )
 
+// ListRoles lists roles for an organization.
+//
+// NOTE: the backend handler for this route does not call lhs.ParseQuery, so
+// LHS filters are accepted by the middleware but silently ignored server-side.
 func (m *middleware) ListRoles(org string, filters ...LHSFilter) ([]*models.Role, *http.Response, error) {
 	var result []*models.Role
 	resp, err := m.GenericRequest(Request{

--- a/cmd/cycloid/middleware/organization_team_members.go
+++ b/cmd/cycloid/middleware/organization_team_members.go
@@ -8,6 +8,10 @@ import (
 	"github.com/cycloidio/cycloid-cli/client/models"
 )
 
+// ListTeamMembers lists members of a team.
+//
+// NOTE: the backend handler for this route does not call lhs.ParseQuery, so
+// LHS filters are accepted by the middleware but silently ignored server-side.
 func (m *middleware) ListTeamMembers(org string, team string, filters ...LHSFilter) ([]*models.MemberTeam, *http.Response, error) {
 	var result []*models.MemberTeam
 	resp, err := m.GenericRequest(Request{

--- a/cmd/cycloid/middleware/organization_team_members.go
+++ b/cmd/cycloid/middleware/organization_team_members.go
@@ -8,12 +8,13 @@ import (
 	"github.com/cycloidio/cycloid-cli/client/models"
 )
 
-func (m *middleware) ListTeamMembers(org string, team string) ([]*models.MemberTeam, *http.Response, error) {
+func (m *middleware) ListTeamMembers(org string, team string, filters ...LHSFilter) ([]*models.MemberTeam, *http.Response, error) {
 	var result []*models.MemberTeam
 	resp, err := m.GenericRequest(Request{
 		Method:       "GET",
 		Organization: &org,
 		Route:        []string{"organizations", org, "teams", team, "members"},
+		LHSFilters:   filters,
 	}, &result)
 	if err != nil {
 		return nil, resp, err

--- a/cmd/cycloid/middleware/organization_teams.go
+++ b/cmd/cycloid/middleware/organization_teams.go
@@ -16,6 +16,9 @@ var (
 	Descending TeamOrderByParam = "desc"
 )
 
+// ListTeams lists teams for an organization.
+//
+// Supported LHS filter attributes: team_canonical, team_name, team_description, team_created_at.
 func (m *middleware) ListTeams(org string, teamNameFilter *string, createdAtFilter *uint64, memberIDFilter *uint32, orderBy *TeamOrderByParam, filters ...LHSFilter) ([]*models.Team, *http.Response, error) {
 	query := url.Values{}
 	if teamNameFilter != nil {

--- a/cmd/cycloid/middleware/organization_teams.go
+++ b/cmd/cycloid/middleware/organization_teams.go
@@ -16,7 +16,7 @@ var (
 	Descending TeamOrderByParam = "desc"
 )
 
-func (m *middleware) ListTeams(org string, teamNameFilter *string, createdAtFilter *uint64, memberIDFilter *uint32, orderBy *TeamOrderByParam) ([]*models.Team, *http.Response, error) {
+func (m *middleware) ListTeams(org string, teamNameFilter *string, createdAtFilter *uint64, memberIDFilter *uint32, orderBy *TeamOrderByParam, filters ...LHSFilter) ([]*models.Team, *http.Response, error) {
 	query := url.Values{}
 	if teamNameFilter != nil {
 		query.Set("team_name", *teamNameFilter)
@@ -37,6 +37,7 @@ func (m *middleware) ListTeams(org string, teamNameFilter *string, createdAtFilt
 		Organization: &org,
 		Route:        []string{"organizations", org, "teams"},
 		Query:        query,
+		LHSFilters:   filters,
 	}, &result)
 	if err != nil {
 		return nil, resp, err

--- a/cmd/cycloid/middleware/stacks.go
+++ b/cmd/cycloid/middleware/stacks.go
@@ -24,6 +24,11 @@ func (m *middleware) GetStack(org, ref string) (*models.ServiceCatalog, *http.Re
 	return result, resp, nil
 }
 
+// ListStacks lists service catalog stacks for an organization.
+//
+// Supported LHS filter attributes: service_catalog_ref, service_catalog_visibility
+// (values: local, shared, hidden), service_catalog_author, service_catalog_blueprint,
+// service_catalog_form_enabled, service_catalog_source_canonical, user_canonical.
 func (m *middleware) ListStacks(org string, filters ...LHSFilter) ([]*models.ServiceCatalog, *http.Response, error) {
 	var result []*models.ServiceCatalog
 	resp, err := m.GenericRequest(Request{
@@ -93,6 +98,10 @@ func (m *middleware) resolveStackVersion(org, stackRef, versionTag, versionBranc
 	return 0, "", fmt.Errorf("stack version commit hash %q not found", versionCommitHash)
 }
 
+// ListStackUseCases lists use cases for a stack version.
+//
+// NOTE: the backend handler for this route does not call lhs.ParseQuery, so
+// LHS filters are accepted by the middleware but silently ignored server-side.
 func (m *middleware) ListStackUseCases(org, ref, versionTag, versionBranch, versionCommitHash string, filters ...LHSFilter) ([]*StackUseCase, *http.Response, error) {
 	// Resolve version parameters to ID
 	versionID, _, err := m.resolveStackVersion(org, ref, versionTag, versionBranch, versionCommitHash)
@@ -118,6 +127,10 @@ func (m *middleware) ListStackUseCases(org, ref, versionTag, versionBranch, vers
 	return result, resp, nil
 }
 
+// ListStackVersions lists versions for a stack.
+//
+// NOTE: the backend handler for this route does not call lhs.ParseQuery, so
+// LHS filters are accepted by the middleware but silently ignored server-side.
 func (m *middleware) ListStackVersions(org, ref string, filters ...LHSFilter) ([]*StackVersion, *http.Response, error) {
 	var result []*StackVersion
 	resp, err := m.GenericRequest(Request{
@@ -177,8 +190,12 @@ func (m *middleware) getDefaultCatalogVersion(org, ref string) (*StackVersion, e
 	return nil, fmt.Errorf("failed to find the default version")
 }
 
-// ListBlueprints lists stacks that are flagged as blueprint using the LHS filter
-// service_catalog_blueprint[eq]=true. Additional caller-supplied filters are merged in.
+// ListBlueprints lists stacks flagged as blueprints (service_catalog_blueprint=true).
+// Additional caller-supplied filters are merged in.
+//
+// Supported LHS filter attributes: same as ListStacks (service_catalog_ref,
+// service_catalog_visibility, service_catalog_author, service_catalog_source_canonical,
+// user_canonical). service_catalog_blueprint is always set to true internally.
 func (m *middleware) ListBlueprints(org string, filters ...LHSFilter) ([]*models.ServiceCatalog, *http.Response, error) {
 	lhsFilters := append(
 		[]LHSFilter{{Attribute: "service_catalog_blueprint", Condition: "eq", Value: "true"}},

--- a/cmd/cycloid/middleware/stacks.go
+++ b/cmd/cycloid/middleware/stacks.go
@@ -24,12 +24,13 @@ func (m *middleware) GetStack(org, ref string) (*models.ServiceCatalog, *http.Re
 	return result, resp, nil
 }
 
-func (m *middleware) ListStacks(org string) ([]*models.ServiceCatalog, *http.Response, error) {
+func (m *middleware) ListStacks(org string, filters ...LHSFilter) ([]*models.ServiceCatalog, *http.Response, error) {
 	var result []*models.ServiceCatalog
 	resp, err := m.GenericRequest(Request{
 		Method:       "GET",
 		Organization: &org,
 		Route:        []string{"organizations", org, "service_catalogs"},
+		LHSFilters:   filters,
 	}, &result)
 	if err != nil {
 		return nil, resp, err
@@ -92,7 +93,7 @@ func (m *middleware) resolveStackVersion(org, stackRef, versionTag, versionBranc
 	return 0, "", fmt.Errorf("stack version commit hash %q not found", versionCommitHash)
 }
 
-func (m *middleware) ListStackUseCases(org, ref, versionTag, versionBranch, versionCommitHash string) ([]*StackUseCase, *http.Response, error) {
+func (m *middleware) ListStackUseCases(org, ref, versionTag, versionBranch, versionCommitHash string, filters ...LHSFilter) ([]*StackUseCase, *http.Response, error) {
 	// Resolve version parameters to ID
 	versionID, _, err := m.resolveStackVersion(org, ref, versionTag, versionBranch, versionCommitHash)
 	if err != nil {
@@ -109,6 +110,7 @@ func (m *middleware) ListStackUseCases(org, ref, versionTag, versionBranch, vers
 		Organization: &org,
 		Route:        []string{"organizations", org, "service_catalogs", ref, "use_cases"},
 		Query:        query,
+		LHSFilters:   filters,
 	}, &result)
 	if err != nil {
 		return nil, resp, err
@@ -116,12 +118,13 @@ func (m *middleware) ListStackUseCases(org, ref, versionTag, versionBranch, vers
 	return result, resp, nil
 }
 
-func (m *middleware) ListStackVersions(org, ref string) ([]*StackVersion, *http.Response, error) {
+func (m *middleware) ListStackVersions(org, ref string, filters ...LHSFilter) ([]*StackVersion, *http.Response, error) {
 	var result []*StackVersion
 	resp, err := m.GenericRequest(Request{
 		Method:       "GET",
 		Organization: &org,
 		Route:        []string{"organizations", org, "service_catalogs", ref, "versions"},
+		LHSFilters:   filters,
 	}, &result)
 	if err != nil {
 		return nil, resp, err
@@ -174,35 +177,25 @@ func (m *middleware) getDefaultCatalogVersion(org, ref string) (*StackVersion, e
 	return nil, fmt.Errorf("failed to find the default version")
 }
 
-// ListBlueprints will list stacks that are flagged as blueprint. Uses the same route as ListStack.
-// TODO: Merge this route with ListStack once we find a way to add LHS filter params to the client.
-func (m *middleware) ListBlueprints(org string) ([]*models.ServiceCatalog, *http.Response, error) {
-	// This method uses custom LHS filter param like the frontend does: `service_catalog_blueprint[eq]=true`
-	// We use url.Values directly here - the encodeQuery will encode this as-is
-	// Note: url.Values{} Encode() will URL-encode the brackets, so we manually build the query string
-	query := url.Values{}
-	query.Set("organization_canonical", org)
-	query.Set("service_catalog_blueprint[eq]", "true")
+// ListBlueprints lists stacks that are flagged as blueprint using the LHS filter
+// service_catalog_blueprint[eq]=true. Additional caller-supplied filters are merged in.
+func (m *middleware) ListBlueprints(org string, filters ...LHSFilter) ([]*models.ServiceCatalog, *http.Response, error) {
+	lhsFilters := append(
+		[]LHSFilter{{Attribute: "service_catalog_blueprint", Condition: "eq", Value: "true"}},
+		filters...,
+	)
 
-	var stacks []*models.ServiceCatalog
+	var result []*models.ServiceCatalog
 	resp, err := m.GenericRequest(Request{
 		Method:       "GET",
 		Organization: &org,
 		Route:        []string{"organizations", org, "service_catalogs"},
-		Query:        query,
-	}, &stacks)
+		LHSFilters:   lhsFilters,
+	}, &result)
 	if err != nil {
 		return nil, resp, err
 	}
-
-	var validBlueprints []*models.ServiceCatalog
-	for _, catalog := range stacks {
-		if catalog.Blueprint {
-			validBlueprints = append(validBlueprints, catalog)
-		}
-	}
-
-	return validBlueprints, resp, nil
+	return result, resp, nil
 }
 
 func (m *middleware) CreateStackFromBlueprint(org, blueprintRef, name, stack, catalogRepository, useCase string) (*models.ServiceCatalog, *http.Response, error) {


### PR DESCRIPTION
## Summary

Implements CLI-108: LHS bracket filters for all `List` middleware methods.

**Root cause of the old `ListBlueprints` bug**: `url.Values.Encode()` percent-encodes brackets (`[`→`%5B`, `]`→`%5D`), so `service_catalog_blueprint[eq]=true` was sent as `service_catalog_blueprint%5Beq%5D=true`, which the API silently ignored. The same issue would have affected any other LHS filter encoded via `url.Values`.

**Fix**: New `buildLHSFilterQuery` helper builds the raw query string with literal brackets and preserves regex metacharacters in values (only encoding structurally significant chars: `&`, `=`, `#`, space).

## Changes

- `cmd/cycloid/middleware/lhs_filter.go` — new file: `LHSFilter` type, `buildLHSFilterQuery`, `lhsEscapeValue`
- `cmd/cycloid/middleware/http_client.go` — add `LHSFilters []LHSFilter` to `Request`
- `cmd/cycloid/middleware/generic_client.go` — handle `LHSFilters` in `GenericRequest`: appends raw LHS query string after standard query params
- `cmd/cycloid/middleware/middleware.go` — update 15 interface signatures with `filters ...LHSFilter`
- All 15 implementation files updated (variadic — all existing callers unchanged)
- `cmd/cycloid/middleware/offline/lhs_filter_test.go` — 18 offline unit tests

### Affected List methods

`ListCatalogRepositories`, `ListConfigRepositories`, `ListStacks`, `ListStackUseCases`, `ListStackVersions`, `ListBlueprints`, `ListCredentials`, `ListMembers`, `ListTeams`, `ListTeamMembers`, `ListProjects`, `ListProjectsEnv`, `ListComponents`, `ListRoles`, `ListAPIKeys`

### `ListBlueprints` fix

Replaces the broken `url.Values` workaround (which silently failed) with proper LHS filter encoding. The client-side `catalog.Blueprint` filtering that compensated for the broken encoding is removed.

## Test plan

- [x] Offline tests: `go test ./cmd/cycloid/middleware/offline/... -run TestLHS` (18 tests pass, no backend needed)
- [ ] Integration test: requires backend — `go test ./cmd/cycloid/middleware/... -run TestListProjects` with filter args
- [ ] Manual: verify `ListBlueprints` now correctly receives `service_catalog_blueprint[eq]=true` (literal brackets) from the server logs

## Usage example

```go
// Filter projects by name pattern
projects, _, err := m.ListProjects(org, middleware.LHSFilter{
    Attribute: "name",
    Condition: "rlike",
    Value:     "my.*project",
})
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)