### PR TITLE
feat(output): table renderer overhaul, --jq flag, cyout error routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ gst
 # direnv
 .direnv
 
+# Local tooling artifacts
+.claude/
+.gitnexus/
+

--- a/changelog/unreleased/CLI-CHANGED-20260412-output-format.yaml
+++ b/changelog/unreleased/CLI-CHANGED-20260412-output-format.yaml
@@ -1,0 +1,8 @@
+component: CLI
+kind: CHANGED
+body: "`--output` now supports table column selection, jq expressions, and field extraction"
+time: 2026-04-12T00:00:01Z
+custom:
+  DETAILS: "Extended `--output` grammar: `table=col1,col2` selects specific columns; `table:noheader` suppresses the header row; `jq=<expr>` runs an arbitrary jq expression over the full JSON response; any other value (e.g. `canonical`, `owner.username`) extracts that field, one value per line. A `--jq <expr>` flag was added as shorthand for `-o jq=<expr>`. Shell completion for `--output` is now model-aware: `cy project list -o <tab>` suggests model fields alongside `json`, `yaml`, `table`, and `jq=`. Pipe pattern enabled: `cy project delete $(cy project list -o canonical)`. Default table columns are curated per resource (e.g. projects show Canonical, Name, Description, Owner)."
+  PR: "999"
+  TYPE: CLI

--- a/changelog/unreleased/CLI-CHANGED-20260412-table-style.yaml
+++ b/changelog/unreleased/CLI-CHANGED-20260412-table-style.yaml
@@ -1,0 +1,8 @@
+component: CLI
+kind: CHANGED
+body: "Table output has been reworked: configurable borders, dynamic column expansion, and persistent default output format"
+time: 2026-04-12T00:00:02Z
+custom:
+  DETAILS: "The default table uses a kubectl-style separator (─) between header and rows. A new `table:border` option switches to nushell-style rounded-border grid (`╭─┬─╮`). On wide terminals, extra struct fields are shown beyond the curated defaults; as the terminal narrows, extra columns are dropped first while curated columns are preserved. Nested structs render as `{record N fields}` instead of the type name. A new `cy output set <value>` command persists the default output format to `~/.config/cycloid-cli/config.yaml`; `cy output get` shows the current effective value; `cy output reset` clears it. The `CY_OUTPUT` environment variable sets the default at runtime. Priority: `--jq` > `--output` > `CY_OUTPUT` > `cy output set` > `table`."
+  PR: "999"
+  TYPE: CLI

--- a/cmd/cycloid/output/cmd.go
+++ b/cmd/cycloid/output/cmd.go
@@ -1,0 +1,92 @@
+package output
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/config"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+)
+
+// NewOutputCmd returns the cobra command for managing the default output format.
+func NewOutputCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "output",
+		Short: "Manage the default output format",
+		Long: `Manage the default --output format persisted in the config file.
+
+The effective output format is resolved in this priority order:
+  1. --jq flag
+  2. --output / -o flag
+  3. CY_OUTPUT environment variable
+  4. Value stored by 'cy output set' (config file)
+  5. "table" (built-in default)`,
+		Args: cobra.NoArgs,
+	}
+	cmd.AddCommand(
+		newSetCmd(),
+		newGetCmd(),
+		newResetCmd(),
+	)
+	return cmd
+}
+
+func newSetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <value>",
+		Short: "Persist a default output format",
+		Args:  cobra.ExactArgs(1),
+		Example: `cy output set table:border
+cy output set json
+cy output set table=canonical,name`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			conf, _ := config.Read()
+			if conf == nil {
+				conf = &config.Config{}
+			}
+			conf.Output = args[0]
+			if err := config.Write(conf); err != nil {
+				return fmt.Errorf("unable to save output config: %w", err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Default output set to %q\n", args[0])
+			return nil
+		},
+	}
+}
+
+func newGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get",
+		Short: "Show the current effective default output format",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			effective, err := cyargs.GetOutput(cmd)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), effective)
+			return nil
+		},
+	}
+}
+
+func newResetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "reset",
+		Short: "Remove the persisted default output format",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			conf, _ := config.Read()
+			if conf == nil {
+				conf = &config.Config{}
+			}
+			conf.Output = ""
+			if err := config.Write(conf); err != nil {
+				return fmt.Errorf("unable to save output config: %w", err)
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "Default output reset to \"table\"")
+			return nil
+		},
+	}
+}

--- a/internal/cyout/errors.go
+++ b/internal/cyout/errors.go
@@ -1,0 +1,130 @@
+package cyout
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/cycloidio/cycloid-cli/client/models"
+)
+
+// apiErrorInfo is satisfied by *middleware.APIResponseError.
+// Defined locally to avoid importing cmd/cycloid/middleware from internal/.
+type apiErrorInfo interface {
+	error
+	HTTPStatusCode() int
+	HTTPRequestMethod() string
+	HTTPRequestPath() string
+	HTTPRequestBody() []byte
+	HTTPResponseBody() []byte
+}
+
+// apiErrorPayloader is optionally implemented by errors that carry a parsed payload.
+type apiErrorPayloader interface {
+	GetPayload() *models.ErrorPayload
+}
+
+var (
+	styleHeader    = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("9"))  // bold red
+	styleDim       = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))             // dim gray
+	styleEndpoint  = lipgloss.NewStyle().Foreground(lipgloss.Color("11"))            // yellow
+	styleCode      = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("8"))  // bold dim
+	styleCmdHint   = lipgloss.NewStyle().Foreground(lipgloss.Color("8")).Italic(true) // dim italic
+)
+
+// printError writes a formatted error block to cmd's stderr.
+// API errors get a rich display with status, method, path, payload details, and request ID.
+// Local errors get a one-line command hint showing what was invoked.
+func printError(cmd *cobra.Command, err error) {
+	w := cmd.ErrOrStderr()
+	if ae, ok := err.(apiErrorInfo); ok {
+		printAPIError(w, ae)
+		return
+	}
+	printLocalError(w, cmd)
+}
+
+func printAPIError(w io.Writer, ae apiErrorInfo) {
+	// Header: "API Error 422 — POST /organizations/myorg/projects"
+	status := ae.HTTPStatusCode()
+	method := ae.HTTPRequestMethod()
+	path := ae.HTTPRequestPath()
+
+	header := fmt.Sprintf("%s %s %s",
+		styleHeader.Render(fmt.Sprintf("API Error %d", status)),
+		styleDim.Render("—"),
+		styleEndpoint.Render(method+" "+path),
+	)
+	fmt.Fprintln(w, header)
+
+	// Optional: sanitized request body
+	if body := ae.HTTPRequestBody(); len(body) > 0 {
+		fmt.Fprintf(w, "  %s %s\n", styleDim.Render("Body:"), string(body))
+	}
+
+	// Error details from parsed payload, or raw response body as fallback
+	var requestID string
+	if pe, ok := ae.(apiErrorPayloader); ok {
+		if p := pe.GetPayload(); p != nil && len(p.Errors) > 0 {
+			for _, item := range p.Errors {
+				if item == nil {
+					continue
+				}
+				printErrorItem(w, item)
+			}
+			requestID = p.RequestID
+		}
+	}
+
+	if requestID == "" {
+		// No structured payload — fall back to raw response body
+		raw := strings.TrimSpace(string(ae.HTTPResponseBody()))
+		if raw != "" {
+			fmt.Fprintf(w, "  %s\n", raw)
+		}
+	}
+
+	if requestID != "" {
+		fmt.Fprintf(w, "  %s\n", styleDim.Render("Request-ID: "+requestID))
+	}
+
+	fmt.Fprintln(w)
+}
+
+func printErrorItem(w io.Writer, item *models.ErrorDetailsItem) {
+	code := ""
+	if item.Code != nil {
+		code = styleCode.Render("["+*item.Code+"]") + " "
+	}
+
+	msg := ""
+	if item.Message != nil {
+		msg = *item.Message
+	}
+
+	fmt.Fprintf(w, "  %s%s\n", code, msg)
+
+	for _, d := range item.Details {
+		if d != "" {
+			fmt.Fprintf(w, "      %s %s\n", styleDim.Render("·"), d)
+		}
+	}
+}
+
+func printLocalError(w io.Writer, cmd *cobra.Command) {
+	// Build "cy project get --org myorg" hint from the command path and set flags
+	var parts []string
+	parts = append(parts, cmd.CommandPath())
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		parts = append(parts, "--"+f.Name+"="+f.Value.String())
+	})
+
+	hint := strings.Join(parts, " ")
+	if hint != "" {
+		fmt.Fprintln(w, styleCmdHint.Render(hint))
+	}
+}

--- a/internal/cyout/errors_test.go
+++ b/internal/cyout/errors_test.go
@@ -1,0 +1,166 @@
+package cyout
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cycloidio/cycloid-cli/client/models"
+)
+
+// fakeAPIError implements apiErrorInfo + apiErrorPayloader for tests.
+type fakeAPIError struct {
+	statusCode int
+	method     string
+	path       string
+	reqBody    []byte
+	respBody   []byte
+	payload    *models.ErrorPayload
+}
+
+func (e *fakeAPIError) Error() string           { return "fake api error" }
+func (e *fakeAPIError) HTTPStatusCode() int     { return e.statusCode }
+func (e *fakeAPIError) HTTPRequestMethod() string { return e.method }
+func (e *fakeAPIError) HTTPRequestPath() string  { return e.path }
+func (e *fakeAPIError) HTTPRequestBody() []byte  { return e.reqBody }
+func (e *fakeAPIError) HTTPResponseBody() []byte { return e.respBody }
+func (e *fakeAPIError) GetPayload() *models.ErrorPayload { return e.payload }
+
+func ptrString(s string) *string { return &s }
+
+func newTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "test"}
+	var buf bytes.Buffer
+	cmd.SetErr(&buf)
+	return cmd
+}
+
+func captureError(cmd *cobra.Command, err error) string {
+	var buf bytes.Buffer
+	cmd.SetErr(&buf)
+	printError(cmd, err)
+	return buf.String()
+}
+
+func TestPrintError_LocalError(t *testing.T) {
+	cmd := newTestCmd()
+	out := captureError(cmd, errors.New("missing flag: --project"))
+	// Local error: only command hint (no "API Error" line), main.go handles the Error: line
+	assert.NotContains(t, out, "API Error")
+}
+
+func TestPrintError_APIErrorWithPayload(t *testing.T) {
+	cmd := newTestCmd()
+	err := &fakeAPIError{
+		statusCode: 422,
+		method:     "GET",
+		path:       "/organizations",
+		respBody:   []byte(`{"errors":[{"code":"Invalid","message":"This endpoint cannot be used with API Key"}]}`),
+		payload: &models.ErrorPayload{
+			Errors: []*models.ErrorDetailsItem{
+				{Code: ptrString("Invalid"), Message: ptrString("This endpoint cannot be used with API Key")},
+			},
+		},
+	}
+	out := captureError(cmd, err)
+	assert.Contains(t, out, "API Error 422")
+	assert.Contains(t, out, "GET")
+	assert.Contains(t, out, "/organizations")
+	assert.Contains(t, out, "Invalid")
+	assert.Contains(t, out, "This endpoint cannot be used with API Key")
+}
+
+func TestPrintError_APIErrorMultipleErrors(t *testing.T) {
+	cmd := newTestCmd()
+	err := &fakeAPIError{
+		statusCode: 422,
+		method:     "POST",
+		path:       "/organizations/myorg/projects",
+		payload: &models.ErrorPayload{
+			Errors: []*models.ErrorDetailsItem{
+				{Code: ptrString("RequiredField"), Message: ptrString("name: must not be empty")},
+				{Code: ptrString("InvalidType"), Message: ptrString("color: must be a valid hex color")},
+			},
+		},
+	}
+	out := captureError(cmd, err)
+	assert.Contains(t, out, "RequiredField")
+	assert.Contains(t, out, "name: must not be empty")
+	assert.Contains(t, out, "InvalidType")
+	assert.Contains(t, out, "color: must be a valid hex color")
+}
+
+func TestPrintError_APIErrorWithDetails(t *testing.T) {
+	cmd := newTestCmd()
+	err := &fakeAPIError{
+		statusCode: 422,
+		method:     "POST",
+		path:       "/organizations/myorg/projects",
+		payload: &models.ErrorPayload{
+			Errors: []*models.ErrorDetailsItem{
+				{
+					Code:    ptrString("InvalidValue"),
+					Message: ptrString("invalid color"),
+					Details: []string{"accepted values are #RRGGBB hex codes"},
+				},
+			},
+		},
+	}
+	out := captureError(cmd, err)
+	assert.Contains(t, out, "invalid color")
+	assert.Contains(t, out, "accepted values are #RRGGBB hex codes")
+}
+
+func TestPrintError_APIErrorWithRequestBody(t *testing.T) {
+	cmd := newTestCmd()
+	err := &fakeAPIError{
+		statusCode: 422,
+		method:     "POST",
+		path:       "/organizations/myorg/credentials",
+		reqBody:    []byte(`{"name":"my-cred","ssh_key":"[REDACTED]"}`),
+		payload: &models.ErrorPayload{
+			Errors: []*models.ErrorDetailsItem{
+				{Code: ptrString("InvalidField"), Message: ptrString("unsupported type")},
+			},
+		},
+	}
+	out := captureError(cmd, err)
+	assert.Contains(t, out, "Body:")
+	assert.Contains(t, out, "my-cred")
+	assert.Contains(t, out, "[REDACTED]")
+}
+
+func TestPrintError_APIErrorRawBodyFallback(t *testing.T) {
+	// No structured payload — falls back to raw response body
+	cmd := newTestCmd()
+	err := &fakeAPIError{
+		statusCode: 503,
+		method:     "GET",
+		path:       "/health",
+		respBody:   []byte("Service Unavailable"),
+	}
+	out := captureError(cmd, err)
+	assert.Contains(t, out, "API Error 503")
+	assert.Contains(t, out, "Service Unavailable")
+}
+
+func TestPrintError_APIErrorWithRequestID(t *testing.T) {
+	cmd := newTestCmd()
+	err := &fakeAPIError{
+		statusCode: 500,
+		method:     "GET",
+		path:       "/organizations",
+		payload: &models.ErrorPayload{
+			RequestID: "550e8400-e29b-41d4-a716-446655440000",
+			Errors: []*models.ErrorDetailsItem{
+				{Code: ptrString("InternalError"), Message: ptrString("unexpected failure")},
+			},
+		},
+	}
+	out := captureError(cmd, err)
+	assert.Contains(t, out, "Request-ID")
+	assert.Contains(t, out, "550e8400-e29b-41d4-a716-446655440000")
+}

--- a/internal/cyout/print.go
+++ b/internal/cyout/print.go
@@ -1,0 +1,47 @@
+// Package cyout provides a one-liner helper to replace the 3-line
+// GetOutput/GetPrinter/SmartPrint boilerplate used across all commands.
+package cyout
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/printer"
+	"github.com/cycloidio/cycloid-cli/printer/factory"
+)
+
+// Print outputs obj (or err) using the command's --output flag.
+// Replaces the GetOutput/GetPrinter/SmartPrint 3-liner.
+func Print(cmd *cobra.Command, obj interface{}, err error, errMsg string) error {
+	return PrintWithOptions(cmd, obj, err, errMsg, printer.Options{})
+}
+
+// PrintWithOptions outputs with explicit column/identifier options for table mode.
+// Commands with curated views call this to specify default columns and identifier.
+//
+// On error: writes a formatted error block to stderr (API errors include status,
+// method, path, payload details, request ID; local errors show command context),
+// then returns the wrapped error so main.go can print the final "Error:" summary line.
+//
+// On success: writes the object to stdout using the selected printer.
+func PrintWithOptions(cmd *cobra.Command, obj interface{}, err error, errMsg string, opts printer.Options) error {
+	if err != nil {
+		printError(cmd, err)
+		if errMsg != "" {
+			return fmt.Errorf("%s: %w", errMsg, err)
+		}
+		return err
+	}
+
+	output, oerr := cyargs.GetOutput(cmd)
+	if oerr != nil {
+		return oerr
+	}
+	p, perr := factory.GetPrinter(output)
+	if perr != nil {
+		return perr
+	}
+	return printer.SmartPrint(p, obj, nil, "", opts, cmd.OutOrStdout())
+}

--- a/internal/cyout/register.go
+++ b/internal/cyout/register.go
@@ -1,0 +1,40 @@
+package cyout
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const annotationFields = "cyout.fields"
+
+// RegisterModel stores the exported field names of model in cmd.Annotations.
+// The global --output completion function reads these to offer model-aware suggestions.
+// Call this in NewXCommand() for every command that outputs structured data.
+func RegisterModel(cmd *cobra.Command, model interface{}) {
+	t := reflect.TypeOf(model)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	fields := make([]string, 0, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		if t.Field(i).IsExported() {
+			fields = append(fields, strings.ToLower(t.Field(i).Name))
+		}
+	}
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[annotationFields] = strings.Join(fields, ",")
+}
+
+// GetModelFields reads the field names stored by RegisterModel from a command's annotations.
+// Returns nil if RegisterModel was not called for this command.
+func GetModelFields(cmd *cobra.Command) []string {
+	raw, ok := cmd.Annotations[annotationFields]
+	if !ok || raw == "" {
+		return nil
+	}
+	return strings.Split(raw, ",")
+}

--- a/printer/factory/factory.go
+++ b/printer/factory/factory.go
@@ -1,32 +1,99 @@
 package factory
 
 import (
-	"fmt"
+	"strings"
 
 	"github.com/cycloidio/cycloid-cli/printer"
-	"github.com/cycloidio/cycloid-cli/printer/json"
+	"github.com/cycloidio/cycloid-cli/printer/field"
+	"github.com/cycloidio/cycloid-cli/printer/jq"
+	jsonprinter "github.com/cycloidio/cycloid-cli/printer/json"
 	"github.com/cycloidio/cycloid-cli/printer/table"
-	"github.com/cycloidio/cycloid-cli/printer/yaml"
+	yamlprinter "github.com/cycloidio/cycloid-cli/printer/yaml"
 )
 
-var (
-	// printer is the lookup table to associate a printer
-	// to a printer type
-	// TODO: use constant + go enum to normalize the printer types
-	printers = map[string]printer.Printer{
-		"yaml":  yaml.YAML{},
-		"yml":   yaml.YAML{},
-		"json":  json.JSON{},
-		"table": table.Table{},
-	}
-)
+var staticPrinters = map[string]printer.Printer{
+	"yaml": yamlprinter.YAML{},
+	"yml":  yamlprinter.YAML{},
+	"json": jsonprinter.JSON{},
+}
 
-// GetPrinter is a helper to return the printer associated to the
-// printer type passed in argument of the method
-func GetPrinter(printer string) (printer.Printer, error) {
-	p, ok := printers[printer]
-	if !ok {
-		return nil, fmt.Errorf("printer does not exist: %s", printer)
+// GetPrinter returns a Printer for the given --output value.
+//
+// Dispatch rules:
+//  1. jq=<expr>           → JQ printer (gojq expression)
+//  2. table[=cols][:opts] → Table printer with options
+//  3. json | yaml | yml   → static printers
+//  4. <anything else>     → Field extractor (any attribute name, dot notation OK)
+func GetPrinter(output string) (printer.Printer, error) {
+	// JQ expression
+	if strings.HasPrefix(output, "jq=") {
+		return jq.New(strings.TrimPrefix(output, "jq="))
 	}
-	return p, nil
+
+	// Table with options (bare "table", "table=cols", or "table:opts")
+	if output == "table" || strings.HasPrefix(output, "table=") || strings.HasPrefix(output, "table:") {
+		opts := parseTableOptions(output)
+		return table.NewWithOptions(opts), nil
+	}
+
+	// Known static printers
+	if p, ok := staticPrinters[output]; ok {
+		return p, nil
+	}
+
+	// Field extraction — any attribute name (e.g. "canonical", "id", "owner.username")
+	return field.New(output), nil
+}
+
+// parseTableOptions parses the table output grammar into printer.TableOptions.
+func parseTableOptions(output string) printer.TableOptions {
+	var opts printer.TableOptions
+	rest := strings.TrimPrefix(output, "table")
+	if rest == "" {
+		return opts
+	}
+
+	// Handle =cols shorthand: extract up to the first ':'
+	if strings.HasPrefix(rest, "=") {
+		rest = rest[1:]
+		colonIdx := strings.Index(rest, ":")
+		var colStr string
+		if colonIdx >= 0 {
+			colStr = rest[:colonIdx]
+			rest = rest[colonIdx:]
+		} else {
+			colStr = rest
+			rest = ""
+		}
+		if colStr != "" {
+			opts.Columns = splitTrim(colStr, ",")
+		}
+	}
+
+	// Parse :key=value and :flag options
+	for _, part := range strings.Split(rest, ":") {
+		part = strings.TrimSpace(part)
+		switch {
+		case part == "":
+			// skip
+		case part == "noheader":
+			opts.NoHeader = true
+		case part == "border":
+			opts.Border = true
+		case strings.HasPrefix(part, "cols="):
+			opts.Columns = splitTrim(strings.TrimPrefix(part, "cols="), ",")
+		}
+	}
+	return opts
+}
+
+func splitTrim(s, sep string) []string {
+	parts := strings.Split(s, sep)
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
 }

--- a/printer/factory/factory_test.go
+++ b/printer/factory/factory_test.go
@@ -24,9 +24,11 @@ func TestGetPrinter(t *testing.T) {
 		assert.Implements(t, (*printer.Printer)(nil), p)
 		assert.IsType(t, json.JSON{}, p)
 	})
-	t.Run("ErrorNotSupported", func(t *testing.T) {
+	t.Run("FieldExtractor", func(t *testing.T) {
+		// Unknown output values fall through to the field extractor, not an error
 		p, err := GetPrinter("not a printer")
-		require.Nil(t, p)
-		assert.Error(t, err)
+		require.NoError(t, err)
+		assert.NotNil(t, p)
+		assert.Implements(t, (*printer.Printer)(nil), p)
 	})
 }

--- a/printer/field/printer.go
+++ b/printer/field/printer.go
@@ -1,0 +1,91 @@
+package field
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+// Field implements the printer interface by extracting a single attribute.
+// One value per line. Supports dot notation for nested access (e.g. "owner.username").
+type Field struct {
+	name string
+}
+
+// New returns a Field printer for the given attribute name.
+func New(name string) *Field {
+	return &Field{name: name}
+}
+
+// Print marshals obj to JSON, extracts the named field, and writes one value per line.
+func (f *Field) Print(obj interface{}, opt printer.Options, w io.Writer) error {
+	raw, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("unable to marshal to JSON: %w", err)
+	}
+	var v interface{}
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return fmt.Errorf("unable to unmarshal JSON: %w", err)
+	}
+
+	switch val := v.(type) {
+	case []interface{}:
+		for _, item := range val {
+			if m, ok := item.(map[string]interface{}); ok {
+				if fv, found := lookup(m, f.name); found {
+					fmt.Fprintln(w, formatValue(fv))
+				}
+			}
+		}
+	case map[string]interface{}:
+		if fv, found := lookup(val, f.name); found {
+			fmt.Fprintln(w, formatValue(fv))
+		}
+	}
+	return nil
+}
+
+// lookup finds a key in a map case-insensitively.
+// Supports dot notation: "owner.username" walks nested maps.
+func lookup(m map[string]interface{}, key string) (interface{}, bool) {
+	parts := strings.SplitN(key, ".", 2)
+	target := strings.ToLower(parts[0])
+
+	for k, v := range m {
+		if strings.ToLower(k) == target {
+			if len(parts) == 1 {
+				return v, true
+			}
+			// Recurse into nested map
+			if nested, ok := v.(map[string]interface{}); ok {
+				return lookup(nested, parts[1])
+			}
+			return nil, false
+		}
+	}
+	return nil, false
+}
+
+// formatValue converts a JSON value to a display string (no JSON quoting for scalars).
+func formatValue(v interface{}) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case float64:
+		// JSON numbers are float64; display integers without decimal point
+		if val == float64(int64(val)) {
+			return fmt.Sprintf("%d", int64(val))
+		}
+		return fmt.Sprintf("%g", val)
+	case bool:
+		return fmt.Sprintf("%t", val)
+	case nil:
+		return ""
+	default:
+		b, _ := json.Marshal(val)
+		return string(b)
+	}
+}

--- a/printer/jq/printer.go
+++ b/printer/jq/printer.go
@@ -1,0 +1,66 @@
+package jq
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/itchyny/gojq"
+
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+// JQ implements the printer interface using a gojq expression.
+// Output is raw (like jq -r): strings printed as-is, other values as pretty JSON.
+type JQ struct {
+	code *gojq.Code
+}
+
+// New compiles a jq expression and returns a JQ printer.
+func New(expr string) (*JQ, error) {
+	query, err := gojq.Parse(expr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid jq expression %q: %w", expr, err)
+	}
+	code, err := gojq.Compile(query)
+	if err != nil {
+		return nil, fmt.Errorf("unable to compile jq expression %q: %w", expr, err)
+	}
+	return &JQ{code: code}, nil
+}
+
+// Print marshals obj to JSON, runs the jq expression, and writes raw output.
+func (j *JQ) Print(obj interface{}, opt printer.Options, w io.Writer) error {
+	raw, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("unable to marshal to JSON: %w", err)
+	}
+	var v interface{}
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return fmt.Errorf("unable to unmarshal JSON: %w", err)
+	}
+
+	iter := j.code.Run(v)
+	for {
+		val, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if jqErr, ok := val.(error); ok {
+			return jqErr
+		}
+		switch typed := val.(type) {
+		case string:
+			fmt.Fprintln(w, typed)
+		case nil:
+			fmt.Fprintln(w, "null")
+		default:
+			b, err := json.MarshalIndent(typed, "", "  ")
+			if err != nil {
+				return fmt.Errorf("unable to marshal jq result: %w", err)
+			}
+			fmt.Fprintln(w, string(b))
+		}
+	}
+	return nil
+}

--- a/printer/options.go
+++ b/printer/options.go
@@ -1,5 +1,31 @@
 package printer
 
-// Options is the struct used
-// to pass options to the printer
-type Options struct{}
+// Options carries per-command display hints for the table printer.
+// Other printers (JSON, YAML, JQ, field) ignore these fields.
+type Options struct {
+	// Columns lists the default columns for table output.
+	// Empty = reflection fallback (backwards compat during migration).
+	Columns []string
+
+	// Identifier is the primary identifier column name.
+	// Always shown even when terminal width forces truncation.
+	Identifier string
+
+	// Transform flattens/computes display values for table output.
+	// Called per-item with the raw model object.
+	// If nil, the table printer uses reflection directly.
+	Transform func(obj interface{}) map[string]string
+}
+
+// TableOptions holds parsed options from the --output table grammar.
+// Grammar: table[=col1,col2][:key=val|:flag]*
+// Set by the factory when parsing the --output flag value.
+type TableOptions struct {
+	// Columns overrides per-command column defaults (from --output table=col1,col2).
+	Columns []string
+	// NoHeader suppresses the header row (from --output table:noheader).
+	NoHeader bool
+	// Border enables the rounded-border grid style (from --output table:border).
+	Border bool
+	// Future: Sort string, Limit int, Wide bool, Compact bool
+}

--- a/printer/table/printer.go
+++ b/printer/table/printer.go
@@ -3,182 +3,614 @@ package table
 import (
 	"fmt"
 	"io"
+	"os"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
-	"github.com/olekukonko/tablewriter"
+	"github.com/charmbracelet/lipgloss"
+	libtable "github.com/charmbracelet/lipgloss/table"
+	"golang.org/x/term"
 
 	"github.com/cycloidio/cycloid-cli/client/models"
 	"github.com/cycloidio/cycloid-cli/printer"
 )
 
-type Table struct{}
-
-// entryFromStruct is a helper to get struct field name
-// which represents the column titles
-func entryFromStruct(obj reflect.Value, h []string) []string {
-	// we can't use obj.NumField() because it will
-	// create a too big slice since it will include
-	// the unexported field
-	values := make([]string, 0)
-	for _, header := range h {
-		value := obj.FieldByName(header)
-		switch value.Kind() {
-		case reflect.String:
-			values = append(values, value.String())
-		case reflect.Uint32, reflect.Uint64:
-			values = append(values, strconv.FormatInt(int64(value.Uint()), 10))
-		case reflect.Bool:
-			values = append(values, fmt.Sprintf("%t", value.Bool()))
-		case reflect.Slice:
-			// Render Slice of strings
-			typ := value.Type().Elem()
-			if typ.Kind() == reflect.String {
-				stringSlice := make([]string, value.Len())
-				for i := 0; i < value.Len(); i++ {
-					stringSlice[i] = value.Index(i).String()
-				}
-				values = append(values, strings.Join(stringSlice[:], "\n"))
-			} else {
-				values = append(values, strconv.Itoa(value.Len()))
-			}
-		case reflect.Ptr:
-			elt := value.Elem()
-			switch elt.Kind() {
-			case reflect.String:
-				values = append(values, elt.String())
-			case reflect.Uint32, reflect.Uint64:
-				values = append(values, strconv.FormatInt(int64(elt.Uint()), 10))
-			case reflect.Int64:
-				t := time.Unix(elt.Int(), 0)
-				values = append(values, t.Format(time.RFC3339))
-			case reflect.Bool:
-				values = append(values, fmt.Sprintf("%t", elt.Bool()))
-			default:
-				// in the case we don't support the type, we print it
-				// for further integration
-				values = append(values, elt.Kind().String())
-			}
-		default:
-			// in the case we don't support the type, we print it
-			// for further integration
-			values = append(values, value.Kind().String())
-		}
-	}
-	return values
+// Table is the default printer, rendering structured data as a terminal table.
+type Table struct {
+	opts printer.TableOptions
 }
 
-// headersFromStruct is a helper to get struct field name
-// which represents the column titles
-func headersFromStruct(obj reflect.Value, opts printer.Options) []string {
-	// we don't set a size to the slice since `NumField`
-	// return the number of struct fields including the
-	// unexported fields
-	headers := make([]string, 0)
-	for i := 0; i < obj.NumField(); i++ {
-		f := obj.Type().Field(i)
-		// remove unexported fields
-		if len(f.PkgPath) != 0 {
+// NewWithOptions returns a Table printer configured with the parsed table options
+// (from --output table[=cols][:flags]).
+func NewWithOptions(opts printer.TableOptions) *Table {
+	return &Table{opts: opts}
+}
+
+// Print renders obj as a terminal table to w.
+func (t *Table) Print(obj interface{}, opts printer.Options, w io.Writer) error {
+	// Guard: nil interface or typed nil pointer — nothing to render.
+	if obj == nil {
+		return nil
+	}
+	if v := reflect.ValueOf(obj); (v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface) && v.IsNil() {
+		return nil
+	}
+
+	// Unwrap API error payloads into their error list for display
+	if apiErr, ok := obj.(interface {
+		GetPayload() *models.ErrorPayload
+	}); ok {
+		if p := apiErr.GetPayload(); p != nil && reflect.TypeOf(p) == reflect.TypeOf(&models.ErrorPayload{}) && len(p.Errors) > 0 {
+			obj = p.Errors
+		}
+	}
+
+	termWidth := terminalWidth()
+
+	// Dynamic column expansion: on wide terminals show all struct fields;
+	// curated columns are protected from being dropped by fitToWidth.
+	userChoseColumns := len(t.opts.Columns) > 0
+	protectedCount := 0
+	buildOpts := t.opts
+
+	if len(opts.Columns) > 0 && termWidth > 0 && !userChoseColumns && opts.Transform == nil {
+		expanded := expandColumns(obj, opts.Columns)
+		if len(expanded) > len(opts.Columns) {
+			buildOpts.Columns = expanded
+			protectedCount = len(opts.Columns)
+		}
+	}
+
+	headers, rows, err := build(obj, buildOpts, opts)
+	if err != nil {
+		return err
+	}
+	if len(headers) == 0 {
+		return nil
+	}
+
+	headers, rows = fitToWidth(headers, rows, opts.Identifier, termWidth, protectedCount, t.opts.Border, userChoseColumns)
+
+	borderStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+
+	var tbl *libtable.Table
+	if t.opts.Border {
+		tbl = libtable.New().
+			Border(lipgloss.RoundedBorder()).
+			BorderRow(false).
+			BorderStyle(borderStyle).
+			StyleFunc(func(row, col int) lipgloss.Style {
+				s := lipgloss.NewStyle().Padding(0, 1)
+				if row == libtable.HeaderRow {
+					return s.Bold(true)
+				}
+				return s
+			})
+	} else {
+		tbl = libtable.New().
+			Border(lipgloss.NormalBorder()).
+			BorderTop(false).
+			BorderBottom(false).
+			BorderLeft(false).
+			BorderRight(false).
+			BorderColumn(false).
+			BorderHeader(true).
+			BorderStyle(borderStyle).
+			StyleFunc(func(row, col int) lipgloss.Style {
+				s := lipgloss.NewStyle().Padding(0, 1)
+				if row == libtable.HeaderRow {
+					return s.Bold(true)
+				}
+				return s
+			})
+	}
+
+	if !t.opts.NoHeader {
+		displayHeaders := make([]string, len(headers))
+		for i, h := range headers {
+			displayHeaders[i] = camelToTitle(h)
+		}
+		tbl = tbl.Headers(displayHeaders...)
+	}
+
+	for _, row := range rows {
+		tbl = tbl.Row(row...)
+	}
+
+	if termWidth > 0 {
+		tbl = tbl.Width(termWidth)
+	}
+
+	output := tbl.Render()
+	fmt.Fprint(w, output)
+	if !strings.HasSuffix(output, "\n") {
+		fmt.Fprintln(w)
+	}
+	return nil
+}
+
+// expandColumns returns curatedCols followed by any additional exported scalar
+// fields from obj that are not already in curatedCols.
+func expandColumns(obj interface{}, curatedCols []string) []string {
+	v := reflect.ValueOf(obj)
+	for (v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface) && !v.IsNil() {
+		v = v.Elem()
+	}
+	if !v.IsValid() || v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
+		return curatedCols
+	}
+	if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
+		if v.Len() == 0 {
+			return curatedCols
+		}
+		first := v.Index(0)
+		for (first.Kind() == reflect.Interface || first.Kind() == reflect.Ptr) && !first.IsNil() {
+			first = first.Elem()
+		}
+		if !first.IsValid() || first.Kind() == reflect.Ptr || first.Kind() == reflect.Interface {
+			return curatedCols
+		}
+		v = first
+	}
+
+	allFields := headersFromStruct(v)
+	if len(allFields) == 0 {
+		return curatedCols
+	}
+
+	curatedSet := make(map[string]bool, len(curatedCols))
+	for _, c := range curatedCols {
+		curatedSet[strings.ToLower(c)] = true
+	}
+
+	result := make([]string, len(curatedCols), len(curatedCols)+len(allFields))
+	copy(result, curatedCols)
+	for _, f := range allFields {
+		if !curatedSet[strings.ToLower(f)] {
+			result = append(result, f)
+		}
+	}
+	return result
+}
+
+// build resolves which columns to use and renders each row.
+func build(obj interface{}, tableOpts printer.TableOptions, printerOpts printer.Options) ([]string, [][]string, error) {
+	// Column priority: user-specified > command defaults > reflection fallback
+	var colNames []string
+	switch {
+	case len(tableOpts.Columns) > 0:
+		colNames = tableOpts.Columns
+	case len(printerOpts.Columns) > 0:
+		colNames = printerOpts.Columns
+	}
+
+	rObj := reflect.ValueOf(obj)
+
+	switch rObj.Kind() {
+	case reflect.Ptr:
+		if rObj.IsNil() {
+			return nil, nil, nil
+		}
+		elt := rObj.Elem()
+		if printerOpts.Transform != nil {
+			m := printerOpts.Transform(obj)
+			headers, row := fromTransformMap(m, colNames)
+			return headers, [][]string{row}, nil
+		}
+		headers := resolveHeaders(elt, colNames)
+		return headers, [][]string{entryFromStruct(elt, headers)}, nil
+
+	case reflect.Slice, reflect.Array:
+		if rObj.Len() == 0 {
+			return nil, nil, nil
+		}
+		// Derive headers from first non-nil element
+		first := firstNonNilElem(rObj)
+		if !first.IsValid() {
+			return nil, nil, nil
+		}
+
+		// String slices: render as a single-column table.
+		// Column name comes from Columns[0] if set, otherwise "Value".
+		if first.Kind() == reflect.String {
+			colName := "Value"
+			if len(colNames) > 0 {
+				colName = colNames[0]
+			}
+			rows := make([][]string, rObj.Len())
+			for i := 0; i < rObj.Len(); i++ {
+				item := rObj.Index(i)
+				if item.Kind() == reflect.Interface {
+					item = item.Elem()
+				}
+				rows[i] = []string{item.String()}
+			}
+			return []string{colName}, rows, nil
+		}
+
+		var headers []string
+		if printerOpts.Transform != nil {
+			// Transform the first item to discover column names
+			m := printerOpts.Transform(rObj.Index(0).Interface())
+			headers, _ = fromTransformMap(m, colNames)
+		} else {
+			headers = resolveHeaders(first, colNames)
+		}
+
+		rows := make([][]string, 0, rObj.Len())
+		for i := 0; i < rObj.Len(); i++ {
+			item := rObj.Index(i)
+			var row []string
+			if printerOpts.Transform != nil {
+				m := printerOpts.Transform(item.Interface())
+				_, row = fromTransformMap(m, headers)
+			} else {
+				elt := derefValue(item)
+				if !elt.IsValid() {
+					// nil element — emit empty row
+					row = make([]string, len(headers))
+				} else {
+					row = entryFromStruct(elt, headers)
+				}
+			}
+			rows = append(rows, row)
+		}
+		return headers, rows, nil
+
+	default:
+		return nil, nil, fmt.Errorf("unable to render table for type: %v", rObj.Kind())
+	}
+}
+
+// firstNonNilElem returns the first non-nil, dereferenced element from a slice/array.
+// Returns an invalid reflect.Value if all elements are nil.
+func firstNonNilElem(rObj reflect.Value) reflect.Value {
+	for i := 0; i < rObj.Len(); i++ {
+		v := derefValue(rObj.Index(i))
+		if v.IsValid() {
+			return v
+		}
+	}
+	return reflect.Value{}
+}
+
+// derefValue unwraps interface and pointer wrappers, returning the underlying value.
+// Returns an invalid reflect.Value if the chain terminates in nil.
+func derefValue(v reflect.Value) reflect.Value {
+	for v.Kind() == reflect.Interface || v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return reflect.Value{}
+		}
+		v = v.Elem()
+	}
+	return v
+}
+
+// resolveHeaders picks the display column names for a struct value.
+// With explicit colNames: case-insensitive match + dot notation support.
+// Without: all exported scalar fields (reflection fallback).
+func resolveHeaders(v reflect.Value, colNames []string) []string {
+	if len(colNames) == 0 {
+		return headersFromStruct(v)
+	}
+	// Build a lowercase→actual-name map from the struct fields
+	fieldMap := make(map[string]string)
+	collectFields(v, "", fieldMap)
+
+	headers := make([]string, 0, len(colNames))
+	for _, name := range colNames {
+		lower := strings.ToLower(name)
+		if actual, ok := fieldMap[lower]; ok {
+			headers = append(headers, actual)
+		} else {
+			// Accept the name as-is (for computed columns via Transform)
+			headers = append(headers, name)
+		}
+	}
+	return headers
+}
+
+// collectFields recursively populates a lowercase→dotPath map for a struct value.
+func collectFields(v reflect.Value, prefix string, out map[string]string) {
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return
+	}
+	for i := 0; i < v.Type().NumField(); i++ {
+		f := v.Type().Field(i)
+		if !f.IsExported() {
 			continue
 		}
-		// the following lines help to avoid
-		// adding pointer to a struct into the table
-		v := obj.FieldByName(f.Name)
-		if v.Kind() == reflect.Ptr {
-			elt := v.Elem()
-			if elt.Kind() == reflect.Struct {
+		path := f.Name
+		if prefix != "" {
+			path = prefix + "." + f.Name
+		}
+		lower := strings.ToLower(path)
+		out[lower] = path
+		// Also map top-level short name without prefix
+		if prefix != "" {
+			out[strings.ToLower(f.Name)] = path
+		}
+	}
+}
+
+// fromTransformMap extracts headers and a row from a Transform output map.
+func fromTransformMap(m map[string]string, colNames []string) ([]string, []string) {
+	if len(colNames) == 0 {
+		// Use map keys in deterministic order (sorted by original insertion isn't possible
+		// with maps, so fall back to the column definition order if available)
+		// For display, collect all keys alphabetically
+		headers := make([]string, 0, len(m))
+		for k := range m {
+			headers = append(headers, k)
+		}
+		row := make([]string, len(headers))
+		for i, h := range headers {
+			row[i] = m[h]
+		}
+		return headers, row
+	}
+	// Use provided colNames as headers
+	lower := make(map[string]string, len(m))
+	for k, v := range m {
+		lower[strings.ToLower(k)] = v
+	}
+	row := make([]string, len(colNames))
+	for i, col := range colNames {
+		row[i] = lower[strings.ToLower(col)]
+	}
+	return colNames, row
+}
+
+// headersFromStruct extracts exported, displayable field names via reflection.
+// Skips pointer-to-struct (nested objects) and unexported fields.
+// Returns nil for non-struct values (strings, ints, etc.).
+func headersFromStruct(v reflect.Value) []string {
+	if !v.IsValid() || v.Kind() != reflect.Struct {
+		return nil
+	}
+	headers := make([]string, 0)
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Type().Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		fv := v.Field(i)
+		// Skip pointer-to-struct (nested objects)
+		if fv.Kind() == reflect.Ptr {
+			if elt := fv.Elem(); elt.IsValid() && elt.Kind() == reflect.Struct {
 				continue
 			}
+		}
+		// Skip direct struct fields
+		if fv.Kind() == reflect.Struct {
+			continue
 		}
 		headers = append(headers, f.Name)
 	}
 	return headers
 }
 
-func generate(obj interface{}, opts printer.Options) ([]string, [][]string, error) {
-	var (
-		headers []string
-		entries [][]string
-		err     error
-	)
-
-	// obj can be a list of pointer or a pointer to struct
-	// we need to handle both cases
-	rObj := reflect.ValueOf(obj)
-
-	switch rObj.Kind() {
-
-	// the object is a pointer to a struct:
-	// example: *models.ExternalBackend
-	case reflect.Ptr:
-		// we need to get the Value targeted by this pointer
-		elt := rObj.Elem()
-		headers = headersFromStruct(elt, opts)
-		entries = make([][]string, 1)
-		entry := entryFromStruct(elt, headers)
-		entries = append(entries, entry)
-
-	// the object is a slice of pointers to a struct
-	// example: []*models.ExternalBackend
-	case reflect.Slice, reflect.Array:
-		if rObj.Len() > 0 {
-			// it's supposed to be an uniform slice
-			// create headers from the first element is enough
-			elt := rObj.Index(0).Elem()
-			headers = headersFromStruct(elt, opts)
-		}
-		entries = make([][]string, rObj.Len())
-		for i := 0; i < rObj.Len(); i++ {
-			elt := rObj.Index(i).Elem()
-			entry := entryFromStruct(elt, headers)
-			entries = append(entries, entry)
-		}
-
-	// default we return an error to help for further object types
-	default:
-		err = fmt.Errorf("unable to get headers for object type: %v", rObj.Kind())
+// entryFromStruct renders a struct value to a string row for the given headers.
+// Supports dot notation in header names (e.g., "Owner.Username").
+func entryFromStruct(obj reflect.Value, headers []string) []string {
+	row := make([]string, len(headers))
+	if !obj.IsValid() {
+		return row
 	}
-
-	return headers, entries, err
+	for i, h := range headers {
+		row[i] = fieldValueStr(obj, h)
+	}
+	return row
 }
 
-func (t Table) Print(obj interface{}, opts printer.Options, w io.Writer) error {
-	// TODO: init the array using the opts
-	// given by the user
-	table := tablewriter.NewWriter(w)
-	table.SetAutoWrapText(false)
-	table.SetAutoFormatHeaders(true)
-	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
-	table.SetAlignment(tablewriter.ALIGN_LEFT)
-	table.SetCenterSeparator("")
-	table.SetColumnSeparator("")
-	table.SetRowSeparator("")
-	table.SetHeaderLine(false)
-	table.SetBorder(false)
-	table.SetTablePadding("\t") // pad with tabs
-	table.SetNoWhiteSpace(true)
+// fieldValueStr extracts a field value from a struct, supporting dot notation.
+func fieldValueStr(v reflect.Value, path string) string {
+	parts := strings.SplitN(path, ".", 2)
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return ""
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return ""
+	}
 
-	// Check if the obj is an API error with payload containing errors details
-	apiErr, ok := obj.(interface {
-		GetPayload() *models.ErrorPayload
-	})
-	if ok {
-		errP := apiErr.GetPayload()
-		if errP != nil && reflect.TypeOf(errP) == reflect.TypeOf(&models.ErrorPayload{}) && len(errP.Errors) > 0 {
-			obj = errP.Errors
+	fv := v.FieldByName(parts[0])
+	if !fv.IsValid() {
+		return ""
+	}
+	if len(parts) == 1 {
+		return renderValue(fv)
+	}
+	return fieldValueStr(fv, parts[1])
+}
+
+// renderValue converts a reflect.Value to a display string.
+func renderValue(v reflect.Value) string {
+	if !v.IsValid() {
+		return ""
+	}
+	switch v.Kind() {
+	case reflect.String:
+		return v.String()
+	case reflect.Uint32, reflect.Uint64:
+		return strconv.FormatUint(v.Uint(), 10)
+	case reflect.Int64:
+		return strconv.FormatInt(v.Int(), 10)
+	case reflect.Int, reflect.Int32:
+		return strconv.FormatInt(v.Int(), 10)
+	case reflect.Float32, reflect.Float64:
+		return strconv.FormatFloat(v.Float(), 'f', -1, 64)
+	case reflect.Bool:
+		return fmt.Sprintf("%t", v.Bool())
+	case reflect.Struct:
+		n := countExportedFields(v.Type())
+		return fmt.Sprintf("{record %d fields}", n)
+	case reflect.Slice:
+		if v.IsNil() {
+			return ""
+		}
+		if v.Type().Elem().Kind() == reflect.String {
+			parts := make([]string, v.Len())
+			for i := 0; i < v.Len(); i++ {
+				parts[i] = v.Index(i).String()
+			}
+			return strings.Join(parts, ", ")
+		}
+		return strconv.Itoa(v.Len())
+	case reflect.Map:
+		if v.IsNil() || v.Len() == 0 {
+			return ""
+		}
+		return fmt.Sprintf("{%d entries}", v.Len())
+	case reflect.Interface:
+		if v.IsNil() {
+			return ""
+		}
+		return renderValue(v.Elem())
+	case reflect.Ptr:
+		elt := v.Elem()
+		if !elt.IsValid() {
+			return ""
+		}
+		switch elt.Kind() {
+		case reflect.String:
+			return elt.String()
+		case reflect.Uint32, reflect.Uint64:
+			return strconv.FormatUint(elt.Uint(), 10)
+		case reflect.Int64:
+			t := time.Unix(elt.Int(), 0)
+			return t.Format(time.RFC3339)
+		case reflect.Int, reflect.Int32:
+			return strconv.FormatInt(elt.Int(), 10)
+		case reflect.Float32, reflect.Float64:
+			return strconv.FormatFloat(elt.Float(), 'f', -1, 64)
+		case reflect.Bool:
+			return fmt.Sprintf("%t", elt.Bool())
+		case reflect.Struct:
+			n := countExportedFields(elt.Type())
+			return fmt.Sprintf("{record %d fields}", n)
+		default:
+			return elt.Kind().String()
+		}
+	default:
+		return v.Kind().String()
+	}
+}
+
+// countExportedFields returns the number of exported fields in a struct type.
+func countExportedFields(t reflect.Type) int {
+	n := 0
+	for i := 0; i < t.NumField(); i++ {
+		if t.Field(i).IsExported() {
+			n++
+		}
+	}
+	return n
+}
+
+// fitToWidth progressively drops rightmost columns when output exceeds terminal width.
+// protectedCount > 0: protect the first protectedCount columns from being dropped.
+// protectedCount == 0: protect the identifier column by name (legacy behavior).
+// If user explicitly chose columns, skip fitting entirely.
+func fitToWidth(headers []string, rows [][]string, identifier string, termWidth, protectedCount int, hasBorder, userChoseColumns bool) ([]string, [][]string) {
+	if termWidth <= 0 || userChoseColumns || len(headers) == 0 {
+		return headers, rows
+	}
+
+	// For legacy mode (no curated cols), find identifier index by name
+	identIdx := -1
+	if protectedCount == 0 {
+		for i, h := range headers {
+			if strings.EqualFold(h, identifier) {
+				identIdx = i
+				break
+			}
 		}
 	}
 
-	// Print our obj
-	headers, entries, err := generate(obj, opts)
-	if err != nil {
-		return err
+	for len(headers) > 1 {
+		if estimateWidth(headers, rows, hasBorder) <= termWidth {
+			break
+		}
+		last := len(headers) - 1
+		if protectedCount > 0 {
+			if last < protectedCount {
+				break
+			}
+		} else {
+			if last == identIdx {
+				break
+			}
+		}
+		headers = headers[:last]
+		for i := range rows {
+			if len(rows[i]) > last {
+				rows[i] = rows[i][:last]
+			}
+		}
 	}
-	table.SetHeader(headers)
-	table.AppendBulk(entries)
+	return headers, rows
+}
 
-	table.Render()
-	return nil
+// estimateWidth estimates the table's rendered width.
+func estimateWidth(headers []string, rows [][]string, hasBorder bool) int {
+	widths := make([]int, len(headers))
+	for i, h := range headers {
+		widths[i] = len(camelToTitle(h))
+	}
+	for _, row := range rows {
+		for i := range widths {
+			if i < len(row) && len(row[i]) > widths[i] {
+				widths[i] = len(row[i])
+			}
+		}
+	}
+	total := 0
+	for _, w := range widths {
+		total += w + 2 // +2 for padding (1 left + 1 right)
+	}
+	if hasBorder {
+		total += len(widths) + 1 // left border + column separators + right border
+	}
+	return total
+}
+
+// terminalWidth returns the current terminal width, or 0 if not a terminal.
+func terminalWidth() int {
+	w, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil {
+		return 0
+	}
+	return w
+}
+
+// camelToTitle converts CamelCase to Title Case with spaces.
+// e.g. "CreatedAt" → "Created At", "ConfigRepositoryCanonical" → "Config Repository Canonical"
+var camelSplitter = regexp.MustCompile(`([a-z])([A-Z])|([A-Z]+)([A-Z][a-z])`)
+
+func camelToTitle(s string) string {
+	// Insert space between camel humps
+	result := camelSplitter.ReplaceAllString(s, "$1$3 $2$4")
+	// Capitalise first letter of each word
+	words := strings.Fields(result)
+	for i, w := range words {
+		if len(w) > 0 {
+			runes := []rune(w)
+			runes[0] = unicode.ToUpper(runes[0])
+			words[i] = string(runes)
+		}
+	}
+	return strings.Join(words, " ")
 }

--- a/printer/table/printer_test.go
+++ b/printer/table/printer_test.go
@@ -2,6 +2,8 @@ package table
 
 import (
 	"bytes"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,13 +35,15 @@ func TestTablePrinter(t *testing.T) {
 			}
 		)
 
-		exp := `A      	B      	C   
-value a	value b	abc	
-       	       	def	
-`
 		err := tab.Print(&obj, printer.Options{}, &b)
 		require.NoError(t, err)
-		assert.Equal(t, b.String(), exp)
+		out := b.String()
+		assert.Contains(t, out, "A")
+		assert.Contains(t, out, "B")
+		assert.Contains(t, out, "C")
+		assert.Contains(t, out, "value a")
+		assert.Contains(t, out, "value b")
+		assert.Contains(t, out, "abc, def")
 	})
 	t.Run("SuccessTimestamp", func(t *testing.T) {
 		now := time.Now()
@@ -50,7 +54,7 @@ value a	value b	abc
 			obj = struct {
 				A *int64 `json:"a"`
 			}{
-				A: int64Ptr(now.Unix()), // int64Ptr(1578325983),
+				A: int64Ptr(now.Unix()),
 			}
 		)
 
@@ -71,7 +75,9 @@ value a	value b	abc
 
 		err := tab.Print(&obj, printer.Options{}, &b)
 		require.NoError(t, err)
-		assert.Equal(t, len(b.String()), 0)
+		// Nested struct field is skipped by headersFromStruct → no data columns.
+		// Since there are no data columns, headers is empty → no output.
+		assert.Empty(t, b.String())
 	})
 	t.Run("SuccessSlicePtr", func(t *testing.T) {
 		var (
@@ -81,19 +87,55 @@ value a	value b	abc
 				A []*struct{}
 			}{
 				A: []*struct{}{
-					&struct{}{},
-					&struct{}{},
+					{},
+					{},
 				},
 			}
 		)
 
-		exp := `A 
-2	
-`
-
 		err := tab.Print(&obj, printer.Options{}, &b)
 		require.NoError(t, err)
-		assert.Equal(t, exp, b.String())
+		out := b.String()
+		assert.Contains(t, out, "A")
+		assert.Contains(t, out, "2")
+	})
+}
+
+func TestTablePrinter_StringSlice(t *testing.T) {
+	t.Run("DefaultColumnName", func(t *testing.T) {
+		var (
+			tab Table
+			b   bytes.Buffer
+		)
+		err := tab.Print([]string{"foo", "bar"}, printer.Options{}, &b)
+		require.NoError(t, err)
+		out := b.String()
+		assert.Contains(t, out, "Value", "default column header should be 'Value'")
+		assert.Contains(t, out, "foo")
+		assert.Contains(t, out, "bar")
+	})
+
+	t.Run("CustomColumnName", func(t *testing.T) {
+		var (
+			tab Table
+			b   bytes.Buffer
+		)
+		err := tab.Print([]string{"proj-one", "proj-two"}, printer.Options{Columns: []string{"Canonical"}}, &b)
+		require.NoError(t, err)
+		out := b.String()
+		assert.Contains(t, out, "Canonical", "column header should be 'Canonical'")
+		assert.Contains(t, out, "proj-one")
+		assert.Contains(t, out, "proj-two")
+	})
+
+	t.Run("EmptySlice", func(t *testing.T) {
+		var (
+			tab Table
+			b   bytes.Buffer
+		)
+		err := tab.Print([]string{}, printer.Options{}, &b)
+		require.NoError(t, err)
+		assert.Empty(t, b.String(), "empty slice should produce no output")
 	})
 }
 
@@ -114,4 +156,305 @@ func TestTablePrinter_APIErrorNilPayloadDoesNotPanic(t *testing.T) {
 	err := tab.Print(&apiErrNilPayload{StatusCode: 404}, printer.Options{}, &b)
 	require.NoError(t, err)
 	assert.NotEmpty(t, b.String())
+}
+
+func TestTablePrinter_BorderOption(t *testing.T) {
+	t.Run("DefaultNoBorder", func(t *testing.T) {
+		type row struct{ Name string }
+		obj := []row{{"alice"}}
+		var b bytes.Buffer
+		err := (&Table{}).Print(obj, printer.Options{}, &b)
+		require.NoError(t, err)
+		out := b.String()
+		assert.NotContains(t, out, "╭", "default should not have rounded corner")
+		assert.NotContains(t, out, "╮", "default should not have rounded corner")
+	})
+
+	t.Run("BorderMode", func(t *testing.T) {
+		type row struct{ Name string }
+		obj := []row{{"alice"}}
+		var b bytes.Buffer
+		tab := Table{opts: printer.TableOptions{Border: true}}
+		err := tab.Print(obj, printer.Options{}, &b)
+		require.NoError(t, err)
+		out := b.String()
+		assert.Contains(t, out, "╭", "border mode should have rounded top-left corner")
+		assert.Contains(t, out, "╰", "border mode should have rounded bottom-left corner")
+		assert.Contains(t, out, "│", "border mode should have vertical separators")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Nil / panic-safety tests
+// ---------------------------------------------------------------------------
+
+func TestTablePrinter_NilSafety(t *testing.T) {
+	t.Run("NilInterface", func(t *testing.T) {
+		var b bytes.Buffer
+		err := (&Table{}).Print(nil, printer.Options{}, &b)
+		require.NoError(t, err)
+		assert.Empty(t, b.String())
+	})
+
+	t.Run("TypedNilPointer", func(t *testing.T) {
+		type item struct{ Name string }
+		var p *item // typed nil
+		var b bytes.Buffer
+		err := (&Table{}).Print(p, printer.Options{}, &b)
+		require.NoError(t, err)
+		assert.Empty(t, b.String())
+	})
+
+	t.Run("SliceOfAllNilPointers", func(t *testing.T) {
+		type item struct{ Name string }
+		objs := []*item{nil, nil, nil}
+		var b bytes.Buffer
+		err := (&Table{}).Print(objs, printer.Options{}, &b)
+		require.NoError(t, err)
+		// All nil → no headers discoverable → no output
+		assert.Empty(t, b.String())
+	})
+
+	t.Run("SliceWithMixedNilPointers", func(t *testing.T) {
+		type item struct{ Name string }
+		objs := []*item{nil, {Name: "alice"}, nil}
+		var b bytes.Buffer
+		err := (&Table{}).Print(objs, printer.Options{}, &b)
+		require.NoError(t, err)
+		out := b.String()
+		assert.Contains(t, out, "Name")
+		assert.Contains(t, out, "alice")
+	})
+
+	t.Run("SliceOfNilInterfaces", func(t *testing.T) {
+		objs := []interface{}{nil, nil}
+		var b bytes.Buffer
+		err := (&Table{}).Print(objs, printer.Options{}, &b)
+		require.NoError(t, err)
+	})
+
+	t.Run("SliceWithMixedNilInterfaces", func(t *testing.T) {
+		type item struct{ Name string }
+		objs := []interface{}{nil, &item{Name: "bob"}, nil}
+		var b bytes.Buffer
+		err := (&Table{}).Print(objs, printer.Options{}, &b)
+		require.NoError(t, err)
+		assert.Contains(t, b.String(), "bob")
+	})
+
+	t.Run("EmptyStruct", func(t *testing.T) {
+		obj := &struct{}{}
+		var b bytes.Buffer
+		err := (&Table{}).Print(obj, printer.Options{}, &b)
+		require.NoError(t, err)
+		assert.Empty(t, b.String())
+	})
+
+	t.Run("StructAllNilFields", func(t *testing.T) {
+		type item struct {
+			Name   *string
+			Count  *int64
+			Nested *struct{ X string }
+		}
+		obj := &item{}
+		var b bytes.Buffer
+		err := (&Table{}).Print(obj, printer.Options{}, &b)
+		require.NoError(t, err)
+		// Name and Count are ptr-to-scalar (shown), Nested is ptr-to-struct (hidden)
+		out := b.String()
+		assert.Contains(t, out, "Name")
+		assert.Contains(t, out, "Count")
+	})
+
+	t.Run("NilSliceField", func(t *testing.T) {
+		type item struct {
+			Name string
+			Tags []string
+		}
+		obj := &item{Name: "test", Tags: nil}
+		var b bytes.Buffer
+		err := (&Table{}).Print(obj, printer.Options{}, &b)
+		require.NoError(t, err)
+		assert.Contains(t, b.String(), "test")
+	})
+
+	t.Run("NilMapField", func(t *testing.T) {
+		type item struct {
+			Name   string
+			Config map[string]string
+		}
+		obj := &item{Name: "test", Config: nil}
+		var b bytes.Buffer
+		err := (&Table{}).Print(obj, printer.Options{}, &b)
+		require.NoError(t, err)
+		assert.Contains(t, b.String(), "test")
+	})
+
+	t.Run("PopulatedMapField", func(t *testing.T) {
+		type item struct {
+			Name   string
+			Config map[string]string
+		}
+		obj := &item{Name: "test", Config: map[string]string{"a": "1", "b": "2"}}
+		var b bytes.Buffer
+		err := (&Table{}).Print(obj, printer.Options{}, &b)
+		require.NoError(t, err)
+		out := b.String()
+		assert.Contains(t, out, "test")
+		assert.Contains(t, out, "{2 entries}")
+	})
+
+	t.Run("NonStructScalarValue", func(t *testing.T) {
+		// Passing a bare string should return an error, not panic
+		var b bytes.Buffer
+		err := (&Table{}).Print("just a string", printer.Options{}, &b)
+		assert.Error(t, err, "bare string should return error")
+	})
+
+	t.Run("NonStructIntValue", func(t *testing.T) {
+		var b bytes.Buffer
+		err := (&Table{}).Print(42, printer.Options{}, &b)
+		assert.Error(t, err, "bare int should return error")
+	})
+
+	t.Run("DotNotationOnNilNestedField", func(t *testing.T) {
+		type Owner struct{ Username string }
+		type item struct {
+			Name  string
+			Owner *Owner
+		}
+		obj := &item{Name: "test", Owner: nil}
+		var b bytes.Buffer
+		tab := NewWithOptions(printer.TableOptions{Columns: []string{"Name", "Owner.Username"}})
+		err := tab.Print(obj, printer.Options{}, &b)
+		require.NoError(t, err)
+		assert.Contains(t, b.String(), "test")
+	})
+
+	t.Run("DotNotationOnNilNestedInSlice", func(t *testing.T) {
+		type Owner struct{ Username string }
+		type item struct {
+			Name  string
+			Owner *Owner
+		}
+		objs := []*item{
+			{Name: "alice", Owner: &Owner{Username: "alice_u"}},
+			{Name: "bob", Owner: nil},
+		}
+		var b bytes.Buffer
+		tab := NewWithOptions(printer.TableOptions{Columns: []string{"Name", "Owner.Username"}})
+		err := tab.Print(objs, printer.Options{}, &b)
+		require.NoError(t, err)
+		out := b.String()
+		assert.Contains(t, out, "alice_u")
+		assert.Contains(t, out, "bob")
+	})
+
+	t.Run("TransformReturnsNilMap", func(t *testing.T) {
+		type item struct{ Name string }
+		obj := &item{Name: "test"}
+		var b bytes.Buffer
+		err := (&Table{}).Print(obj, printer.Options{
+			Transform: func(interface{}) map[string]string { return nil },
+		}, &b)
+		require.NoError(t, err)
+		// nil map → empty headers → no output
+		assert.Empty(t, b.String())
+	})
+
+	t.Run("ExpandColumnsNilSliceElement", func(t *testing.T) {
+		type item struct{ Name string }
+		objs := []*item{nil}
+		result := expandColumns(objs, []string{"Name"})
+		assert.Equal(t, []string{"Name"}, result, "should return curated cols when all nil")
+	})
+}
+
+func TestRenderValue(t *testing.T) {
+	t.Run("Struct", func(t *testing.T) {
+		type inner struct {
+			A string
+			B int
+		}
+		v := reflect.ValueOf(inner{"x", 1})
+		result := renderValue(v)
+		assert.Equal(t, "{record 2 fields}", result)
+	})
+
+	t.Run("PtrToStruct", func(t *testing.T) {
+		type inner struct {
+			A string
+			B int
+			C bool
+		}
+		val := inner{}
+		v := reflect.ValueOf(&val)
+		result := renderValue(v)
+		assert.Equal(t, "{record 3 fields}", result)
+	})
+
+	t.Run("Int", func(t *testing.T) {
+		v := reflect.ValueOf(int(42))
+		assert.Equal(t, "42", renderValue(v))
+	})
+
+	t.Run("Int32", func(t *testing.T) {
+		v := reflect.ValueOf(int32(7))
+		assert.Equal(t, "7", renderValue(v))
+	})
+
+	t.Run("Float32", func(t *testing.T) {
+		v := reflect.ValueOf(float32(3.14))
+		result := renderValue(v)
+		assert.Contains(t, result, "3.14")
+	})
+
+	t.Run("Float64", func(t *testing.T) {
+		v := reflect.ValueOf(float64(2.718))
+		result := renderValue(v)
+		assert.Contains(t, result, "2.718")
+	})
+}
+
+func TestEstimateWidth(t *testing.T) {
+	headers := []string{"Name", "Status"}
+	rows := [][]string{{"alice", "active"}}
+
+	withoutBorder := estimateWidth(headers, rows, false)
+	withBorder := estimateWidth(headers, rows, true)
+
+	// Border adds numCols+1 = 3 chars
+	assert.Equal(t, withoutBorder+3, withBorder, "border mode should add numCols+1 chars")
+}
+
+func TestExpandColumns(t *testing.T) {
+	type full struct {
+		Canonical string
+		Name      string
+		Extra1    string
+		Extra2    string
+	}
+	obj := []full{{"c1", "n1", "e1", "e2"}}
+	curated := []string{"Canonical", "Name"}
+
+	expanded := expandColumns(obj, curated)
+
+	assert.Equal(t, []string{"Canonical", "Name"}, expanded[:2], "curated cols should come first")
+	assert.Len(t, expanded, 4, "should include all 4 fields")
+	assert.Contains(t, expanded, "Extra1")
+	assert.Contains(t, expanded, "Extra2")
+}
+
+func TestFitToWidth_ProtectedCount(t *testing.T) {
+	headers := []string{"Canonical", "Name", "Extra1", "Extra2"}
+	rows := [][]string{
+		{"c1", "n1", strings.Repeat("x", 30), strings.Repeat("y", 30)},
+	}
+
+	// protectedCount=2 protects Canonical+Name; Extra1 and Extra2 can be dropped
+	fitted, _ := fitToWidth(headers, rows, "", 40, 2, false, false)
+
+	// Canonical and Name must survive
+	assert.Contains(t, fitted, "Canonical")
+	assert.Contains(t, fitted, "Name")
 }


### PR DESCRIPTION
## Summary

- Overhauled table renderer in `printer/` — consistent column formatting and alignment
- Added `--jq` flag for JQ-style filtering on JSON output
- Migrated error routing to `cyout.PrintWithOptions` / `cyout.Print` — errors go to stderr, results to stdout
- Added `cmd/cycloid/output/` command surface

## Part of

This is **1 of 3** PRs split from #426. Stack:

1. **This PR** — output system (base: `develop`)
2. `feat/command-behavior` — command migrations, multi-arg batch ops, flags-additive pattern (base: this PR)
3. `feat/plugin-commands` — plugin management commands (base: PR 2)

## Test plan

- [ ] `cy <any command> --output json | jq '.'` — confirm JSON output still valid
- [ ] `cy <any command> --output table` — confirm table renders correctly
- [ ] Error messages go to stderr (`cy bad-command 2>/dev/null` shows nothing; `cy bad-command 2>&1 >/dev/null` shows error)
- [ ] `--jq` flag filters JSON output as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)