### PR TITLE
feat(plugins): plugin management commands

### DIFF
--- a/changelog/unreleased/CLI-ADDED-20260411-plugin-install-version-id.yaml
+++ b/changelog/unreleased/CLI-ADDED-20260411-plugin-install-version-id.yaml
@@ -1,0 +1,8 @@
+component: CLI
+kind: ADDED
+body: "`cy plugin install --version-id` to pin a specific plugin version at install time"
+time: 2026-04-11T00:00:00Z
+custom:
+  DETAILS: "Adds an optional `--version-id` flag to `cy plugin install`. When provided, the install request includes the target version ID, enabling CI/CD workflows to pin exact plugin versions without raw API calls."
+  PR: "426"
+  TYPE: CLI

--- a/changelog/unreleased/CLI-ADDED-20260411-plugin-install-version-id.yaml
+++ b/changelog/unreleased/CLI-ADDED-20260411-plugin-install-version-id.yaml
@@ -1,8 +1,8 @@
 component: CLI
 kind: ADDED
-body: "`cy plugin install --version-id` to pin a specific plugin version at install time"
+body: "`cy plugin registry plugin version install --retry` to idempotently install a plugin version"
 time: 2026-04-11T00:00:00Z
 custom:
-  DETAILS: "Adds an optional `--version-id` flag to `cy plugin install`. When provided, the install request includes the target version ID, enabling CI/CD workflows to pin exact plugin versions without raw API calls."
-  PR: "426"
+  DETAILS: "Adds `--retry` flag to `cy plugin registry plugin version install`. When the install returns HTTP 409 (already installed), the command retries via the retry endpoint instead of failing. Safe for use in CI/CD pipelines."
+  PR: "432"
   TYPE: CLI

--- a/changelog/unreleased/CLI-ADDED-20260411-plugin-version-docker-image.yaml
+++ b/changelog/unreleased/CLI-ADDED-20260411-plugin-version-docker-image.yaml
@@ -1,0 +1,8 @@
+component: CLI
+kind: ADDED
+body: "`cy plugin registry plugin version publish --docker-image` to publish Docker image-based plugin versions"
+time: 2026-04-11T00:00:01Z
+custom:
+  DETAILS: "Adds `--docker-image` as a mutually exclusive alternative to `--url` in the version publish command. Accepts Docker image references (e.g. `registry:5000/org/plugin:tag`) that are not valid URIs, which the existing `--url` flag rejects."
+  PR: "426"
+  TYPE: CLI

--- a/changelog/unreleased/CLI-CHANGED-20260429-plugin-promoted.yaml
+++ b/changelog/unreleased/CLI-CHANGED-20260429-plugin-promoted.yaml
@@ -1,0 +1,8 @@
+component: CLI
+kind: CHANGED
+body: "`cy beta plugin` commands promoted to top-level `cy plugin`"
+time: 2026-04-29T00:00:00Z
+custom:
+  DETAILS: "Plugin management commands are no longer experimental. `cy beta plugin` is removed; use `cy plugin` instead. This release also adds `cy plugin registry update`, `cy plugin registry plugin update`, `cy plugin component list/relation-set`, `cy plugin widget list/query`, and `cy plugin component widget list/query`."
+  PR: "426"
+  TYPE: CLI

--- a/client/models/plugin_install_runtime_log.go
+++ b/client/models/plugin_install_runtime_log.go
@@ -26,6 +26,11 @@ type PluginInstallRuntimeLog struct {
 	// Text of the log line
 	// Required: true
 	Message *string `json:"message"`
+
+	// Timestamp of the log line
+	// Required: true
+	// Format: date-time
+	Timestamp *strfmt.DateTime `json:"timestamp"`
 }
 
 // Validate validates this plugin install runtime log
@@ -37,6 +42,10 @@ func (m *PluginInstallRuntimeLog) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateMessage(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateTimestamp(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -62,6 +71,19 @@ func (m *PluginInstallRuntimeLog) validateID(formats strfmt.Registry) error {
 func (m *PluginInstallRuntimeLog) validateMessage(formats strfmt.Registry) error {
 
 	if err := validate.Required("message", "body", m.Message); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *PluginInstallRuntimeLog) validateTimestamp(formats strfmt.Registry) error {
+
+	if err := validate.Required("timestamp", "body", m.Timestamp); err != nil {
+		return err
+	}
+
+	if err := validate.FormatOf("timestamp", "body", "date-time", m.Timestamp.String(), formats); err != nil {
 		return err
 	}
 

--- a/cmd/cycloid/beta/config/interpolate.go
+++ b/cmd/cycloid/beta/config/interpolate.go
@@ -9,8 +9,8 @@ import (
 	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
 	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
 	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
 	"github.com/cycloidio/cycloid-cli/printer"
-	"github.com/cycloidio/cycloid-cli/printer/factory"
 )
 
 func NewInterpolateCmd() *cobra.Command {
@@ -45,16 +45,6 @@ func interpolate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	output, err := cyargs.GetOutput(cmd)
-	if err != nil {
-		return err
-	}
-
-	// This endpoint doesn't make sense in table mode
-	if output == "table" {
-		output = "json"
-	}
-
 	api := common.NewAPI()
 	m := middleware.NewMiddleware(api)
 
@@ -80,15 +70,6 @@ func interpolate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	p, err := factory.GetPrinter(output)
-	if err != nil {
-		return errors.Wrap(err, "unable to get printer")
-	}
-
 	config, _, err := m.InterpolateFormsConfig(org, project, env, component, stackRef, useCase, inputs)
-	if err != nil {
-		return printer.SmartPrint(p, nil, err, "failed to interpolate config", printer.Options{}, cmd.OutOrStderr())
-	}
-
-	return printer.SmartPrint(p, config, nil, "failed to interpolate config", printer.Options{}, cmd.OutOrStdout())
+	return cyout.PrintWithOptions(cmd, config, err, "failed to interpolate config", printer.Options{})
 }

--- a/cmd/cycloid/middleware/middleware.go
+++ b/cmd/cycloid/middleware/middleware.go
@@ -192,7 +192,6 @@ type Middleware interface {
 	// organization_plugins (installs)
 	ListPlugins(org string) ([]*models.Plugin, *http.Response, error)
 	GetPlugin(org string, id uint32) (*models.PluginInstall, *http.Response, error)
-	CreatePlugin(org string, versionID *uint32, config map[string]string) (*models.PluginInstall, *http.Response, error)
 	UpdatePlugin(org string, id, versionID uint32, config map[string]string) (*models.PluginInstall, *http.Response, error)
 	DeletePlugin(org string, id uint32) (*http.Response, error)
 	ListPluginLogs(org string, id uint32) (*models.PluginLogs, *http.Response, error)

--- a/cmd/cycloid/middleware/plugins.go
+++ b/cmd/cycloid/middleware/plugins.go
@@ -115,32 +115,6 @@ func (m *middleware) GetPlugin(org string, id uint32) (*models.PluginInstall, *h
 	return result, resp, nil
 }
 
-// createPluginBody is a superset of models.NewPluginInstall that optionally
-// includes a version ID. The generated model is not used here so that we can
-// add fields without editing auto-generated code.
-type createPluginBody struct {
-	Configuration   map[string]string `json:"configuration"`
-	PluginVersionID *uint32           `json:"plugin_version_id,omitempty"`
-}
-
-func (m *middleware) CreatePlugin(org string, versionID *uint32, config map[string]string) (*models.PluginInstall, *http.Response, error) {
-	body := &createPluginBody{
-		Configuration:   config,
-		PluginVersionID: versionID,
-	}
-	var result *models.PluginInstall
-	resp, err := m.GenericRequest(Request{
-		Method:       "POST",
-		Organization: &org,
-		Route:        []string{"organizations", org, "plugins"},
-		Body:         body,
-	}, &result)
-	if err != nil {
-		return nil, resp, err
-	}
-	return result, resp, nil
-}
-
 func (m *middleware) UpdatePlugin(org string, id, versionID uint32, config map[string]string) (*models.PluginInstall, *http.Response, error) {
 	body := &models.UpdatePluginInstall{
 		Configuration:   config,
@@ -196,17 +170,19 @@ func (m *middleware) ListPluginRegistries(org string) ([]*models.PluginRegistry,
 	return result, resp, nil
 }
 
+// GetPluginRegistry retrieves a single plugin registry by ID.
+// The API has no GET-by-ID endpoint for registries, so this lists all and filters.
 func (m *middleware) GetPluginRegistry(org string, id uint32) (*models.PluginRegistry, *http.Response, error) {
-	var result *models.PluginRegistry
-	resp, err := m.GenericRequest(Request{
-		Method:       "GET",
-		Organization: &org,
-		Route:        []string{"organizations", org, "plugin_registries", fmt.Sprint(id)},
-	}, &result)
+	regs, resp, err := m.ListPluginRegistries(org)
 	if err != nil {
 		return nil, resp, err
 	}
-	return result, resp, nil
+	for _, r := range regs {
+		if r.ID != nil && *r.ID == id {
+			return r, resp, nil
+		}
+	}
+	return nil, resp, fmt.Errorf("plugin registry %d not found", id)
 }
 
 func (m *middleware) CreatePluginRegistry(org, name, url string) (*models.PluginRegistry, *http.Response, error) {
@@ -254,15 +230,19 @@ func (m *middleware) DeletePluginRegistry(org string, id uint32) (*http.Response
 
 // --- Registry Plugins ---
 
+// ListRegistryPlugins lists plugins belonging to a specific registry.
+// The API has no GET /plugin_registries/{id}/plugins endpoint (only POST for create),
+// so we list all plugins and filter by registry ID.
 func (m *middleware) ListRegistryPlugins(org string, registryID uint32) ([]*models.Plugin, *http.Response, error) {
-	var result []*models.Plugin
-	resp, err := m.GenericRequest(Request{
-		Method:       "GET",
-		Organization: &org,
-		Route:        registryPluginsRoute(org, registryID),
-	}, &result)
+	all, resp, err := m.ListPlugins(org)
 	if err != nil {
 		return nil, resp, err
+	}
+	var result []*models.Plugin
+	for _, p := range all {
+		if p.Registry != nil && p.Registry.ID != nil && *p.Registry.ID == registryID {
+			result = append(result, p)
+		}
 	}
 	return result, resp, nil
 }

--- a/cmd/cycloid/middleware/plugins_test.go
+++ b/cmd/cycloid/middleware/plugins_test.go
@@ -1,0 +1,317 @@
+package middleware_test
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cycloidio/cycloid-cli/pkg/testcfg"
+)
+
+// pluginsMiddlewareEnabled reports whether the plugin middleware tests should run.
+func pluginsMiddlewareEnabled() bool {
+	return os.Getenv("CY_TEST_E2E_PLUGINS") == "1"
+}
+
+// uniquePluginImage generates a unique semver-tagged plugin image URL for use with
+// CreatePluginVersion. The plugin-registry enforces a global unique constraint on
+// version URLs, so each version creation requires a different docker image tag.
+func uniquePluginImage(t *testing.T) string {
+	t.Helper()
+	tag := fmt.Sprintf("1.0.%d", rand.Intn(999999))
+	local := fmt.Sprintf("localhost:5000/plugin-hello-world:%s", tag)
+	api := fmt.Sprintf("docker-registry:5000/plugin-hello-world:%s", tag)
+
+	run := func(name string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(name, args...)
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("uniquePluginImage: %q %v failed: %v", name, args, err)
+		}
+	}
+	run("docker", "tag", "cycloid/plugin-hello-world:latest", local)
+	run("docker", "push", local)
+	return api
+}
+
+func TestPluginManagersCRUD(t *testing.T) {
+	if !pluginsMiddlewareEnabled() {
+		t.Skip("set CY_TEST_E2E_PLUGINS=1 to run plugin middleware tests")
+	}
+
+	m := config.Middleware
+	org := config.Org
+
+	t.Run("List", func(t *testing.T) {
+		managers, resp, err := m.ListPluginManagers(org)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.NotNil(t, managers)
+	})
+
+	t.Run("AcceptTestPluginManager", func(t *testing.T) {
+		mgr, err := config.AcceptPluginManager(t)
+		require.NoError(t, err)
+		require.NotNil(t, mgr)
+		// API returns "invite_accepted" once accepted (not "accepted").
+		assert.Contains(t, []string{"accepted", "invite_accepted"}, *mgr.InviteStatus)
+	})
+}
+
+func TestPluginRegistryCRUD(t *testing.T) {
+	if !pluginsMiddlewareEnabled() {
+		t.Skip("set CY_TEST_E2E_PLUGINS=1 to run plugin middleware tests")
+	}
+
+	m := config.Middleware
+	org := config.Org
+	name := testcfg.RandomCanonical("mw-registry")
+	regURL := "http://plugin-registry:4000"
+
+	reg, _, err := m.CreatePluginRegistry(org, name, regURL)
+	require.NoError(t, err)
+	require.NotNil(t, reg)
+	assert.Equal(t, name, *reg.Name)
+
+	defer func() {
+		if _, delErr := m.DeletePluginRegistry(org, *reg.ID); delErr != nil {
+			t.Logf("cleanup: delete registry %d: %v", *reg.ID, delErr)
+		}
+	}()
+
+	t.Run("Get", func(t *testing.T) {
+		got, resp, err := m.GetPluginRegistry(org, *reg.ID)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, name, *got.Name)
+	})
+
+	t.Run("List", func(t *testing.T) {
+		regs, resp, err := m.ListPluginRegistries(org)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		var found bool
+		for _, r := range regs {
+			if *r.ID == *reg.ID {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "created registry not found in list")
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		newName := name + "-upd"
+		updated, resp, err := m.UpdatePluginRegistry(org, *reg.ID, newName)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, newName, *updated.Name)
+	})
+}
+
+func TestRegistryPluginCRUD(t *testing.T) {
+	if !pluginsMiddlewareEnabled() {
+		t.Skip("set CY_TEST_E2E_PLUGINS=1 to run plugin middleware tests")
+	}
+
+	m := config.Middleware
+	org := config.Org
+
+	reg, err := config.NewTestPluginRegistry(t, testcfg.RandomCanonical("mw-reg-pl"), "http://plugin-registry:4000")
+	require.NoError(t, err)
+
+	pluginName := testcfg.RandomCanonical("mw-plugin")
+	plugin, _, err := m.CreateRegistryPlugin(org, *reg.ID, pluginName)
+	require.NoError(t, err)
+	require.NotNil(t, plugin)
+
+	defer func() {
+		if _, delErr := m.DeleteRegistryPlugin(org, *reg.ID, *plugin.ID); delErr != nil {
+			t.Logf("cleanup: delete plugin %d: %v", *plugin.ID, delErr)
+		}
+	}()
+
+	t.Run("Get", func(t *testing.T) {
+		got, resp, err := m.GetRegistryPlugin(org, *reg.ID, *plugin.ID)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, pluginName, *got.Name)
+	})
+
+	t.Run("List", func(t *testing.T) {
+		plugins, resp, err := m.ListRegistryPlugins(org, *reg.ID)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		var found bool
+		for _, p := range plugins {
+			if *p.ID == *plugin.ID {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "created plugin not found in list")
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		newName := pluginName + "-upd"
+		updated, resp, err := m.UpdateRegistryPlugin(org, *reg.ID, *plugin.ID, newName)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, newName, *updated.Name)
+	})
+}
+
+func TestPluginVersionCRUD(t *testing.T) {
+	if !pluginsMiddlewareEnabled() {
+		t.Skip("set CY_TEST_E2E_PLUGINS=1 to run plugin middleware tests")
+	}
+
+	m := config.Middleware
+	org := config.Org
+
+	reg, err := config.NewTestPluginRegistry(t, testcfg.RandomCanonical("mw-reg-ver"), "http://plugin-registry:4000")
+	require.NoError(t, err)
+
+	plugin, err := config.NewTestPluginInRegistry(t, *reg.ID, testcfg.RandomCanonical("mw-plver"))
+	require.NoError(t, err)
+
+	ver, _, err := m.CreatePluginVersion(org, *reg.ID, *plugin.ID, uniquePluginImage(t))
+	require.NoError(t, err)
+	require.NotNil(t, ver)
+
+	defer func() {
+		if _, delErr := m.DeletePluginVersion(org, *reg.ID, *plugin.ID, *ver.ID); delErr != nil {
+			t.Logf("cleanup: delete version %d: %v", *ver.ID, delErr)
+		}
+	}()
+
+	t.Run("Get", func(t *testing.T) {
+		got, resp, err := m.GetPluginVersion(org, *reg.ID, *plugin.ID, *ver.ID)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, *ver.ID, *got.ID)
+	})
+
+	t.Run("List", func(t *testing.T) {
+		versions, resp, err := m.ListPluginVersions(org, *reg.ID, *plugin.ID)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.NotEmpty(t, versions)
+	})
+
+	t.Run("ListLogs", func(t *testing.T) {
+		logs, resp, err := m.ListPluginVersionLogs(org, *reg.ID, *plugin.ID, *ver.ID)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.NotNil(t, logs)
+	})
+}
+
+func TestPluginInstallAndGet(t *testing.T) {
+	if !pluginsMiddlewareEnabled() {
+		t.Skip("set CY_TEST_E2E_PLUGINS=1 to run plugin middleware tests")
+	}
+
+	m := config.Middleware
+	org := config.Org
+
+	_, err := config.AcceptPluginManager(t)
+	require.NoError(t, err)
+
+	reg, err := config.NewTestPluginRegistry(t, testcfg.RandomCanonical("mw-reg-ins"), "http://plugin-registry:4000")
+	require.NoError(t, err)
+
+	plugin, err := config.NewTestPluginInRegistry(t, *reg.ID, testcfg.RandomCanonical("mw-plinst"))
+	require.NoError(t, err)
+
+	ver, err := config.NewTestPluginVersion(t, *reg.ID, *plugin.ID, uniquePluginImage(t))
+	require.NoError(t, err)
+
+	// Install returns 200 with PluginInstall body (swagger: "200 The Plugin Install data").
+	resp, err := m.InstallPluginVersion(org, *reg.ID, *plugin.ID, *ver.ID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Resolve install ID from list — allow a moment for the record to appear.
+	var installID uint32
+	for i := 0; i < 10; i++ {
+		plugins, _, _ := m.ListPlugins(org)
+		for _, p := range plugins {
+			if p.Name != nil && *p.Name == *plugin.Name && p.Install != nil {
+				installID = *p.Install.ID
+			}
+		}
+		if installID != 0 {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	require.NotZero(t, installID, "install record not found in ListPlugins")
+
+	t.Cleanup(func() {
+		if _, delErr := m.DeletePlugin(org, installID); delErr != nil {
+			t.Logf("cleanup: delete plugin install %d: %v", installID, delErr)
+		}
+	})
+
+	t.Run("GetInstall", func(t *testing.T) {
+		install, resp, err := m.GetPlugin(org, installID)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		require.NotNil(t, install)
+		// The plugin-manager deploys asynchronously; status may be pending/running.
+		assert.NotNil(t, install.ID)
+	})
+
+	t.Run("ListInstalls", func(t *testing.T) {
+		plugins, resp, err := m.ListPlugins(org)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		var found bool
+		for _, p := range plugins {
+			if p.Install != nil && *p.Install.ID == installID {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "install %d not found in ListPlugins", installID)
+	})
+
+	t.Run("RetryIdempotent", func(t *testing.T) {
+		// Second install should return 409 Conflict; retry endpoint returns 204.
+		retryResp, err := m.InstallPluginVersion(org, *reg.ID, *plugin.ID, *ver.ID, nil)
+		if err == nil {
+			// First install on a freshly reset DB — no conflict yet.
+			assert.Contains(t, []int{http.StatusOK, http.StatusAccepted}, retryResp.StatusCode)
+			return
+		}
+		if retryResp != nil && retryResp.StatusCode == http.StatusConflict {
+			retryResp2, retryErr := m.RetryPluginVersion(org, *reg.ID, *plugin.ID, *ver.ID)
+			require.NoError(t, retryErr)
+			assert.Equal(t, http.StatusNoContent, retryResp2.StatusCode)
+			return
+		}
+		t.Fatalf("unexpected error on second install: %v", err)
+	})
+
+	t.Run("Logs", func(t *testing.T) {
+		logs, resp, err := m.ListPluginLogs(org, installID)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.NotNil(t, logs)
+	})
+
+	t.Run("ListWidgets", func(t *testing.T) {
+		widgets, resp, err := m.ListPluginWidgets(org, "sideMenuPage")
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.NotNil(t, widgets)
+	})
+}

--- a/cmd/cycloid/plugins/cmd.go
+++ b/cmd/cycloid/plugins/cmd.go
@@ -1,0 +1,78 @@
+package plugins
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/plugins/component"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/plugins/manager"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/plugins/registry"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/plugins/widget"
+)
+
+func NewCommands() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "plugin",
+		Aliases: []string{"plugins"},
+		Short:   "Manage plugins",
+		Long: `Manage plugins in your organization.
+
+Concepts and dependency order:
+
+  Registry   An external source of plugins (Docker-registry-compatible).
+             Must exist before any plugin can be installed.
+             → cy plugin registry
+
+  Plugin     A plugin definition published to a registry. Has a name,
+             description, and one or more versions.
+             → cy plugin registry plugin
+
+  Version    A specific release of a plugin. Bundles a Docker image and
+             a manifest that declares: required configuration fields,
+             widgets (UI panels), and data queries.
+             → cy plugin registry plugin version
+
+  Manager    The agent that deploys and runs plugin containers in your
+             infrastructure. Required before the first install.
+             → cy plugin manager
+
+  Install    Running instance of a plugin version, deployed by the manager
+             with org-specific configuration (API keys, endpoints, etc.).
+             This is what appears in 'cy plugin list'.
+             → cy plugin registry plugin version install
+
+  Widget     A UI panel backed by a running plugin. Each widget wraps one
+             pre-configured query from the plugin manifest. Widgets are
+             created automatically from the manifest on install.
+             → cy plugin widget
+
+To install a plugin for the first time:
+
+  # 1. Add a registry
+  cy plugin registry add --url https://registry.example.com
+
+  # 2. Browse available plugins and versions
+  cy plugin registry plugin list my-registry
+  cy plugin registry plugin version list my-registry my-plugin
+
+  # 3. Install (configuration keys are declared in the version manifest)
+  cy plugin registry plugin version install my-registry my-plugin <version-id> \
+    --config api_url=https://api.example.com \
+    --config api_token=secret
+
+Once installed, use 'cy plugin upgrade' to change version or reconfigure,
+and 'cy plugin uninstall' to remove.`,
+	}
+
+	cmd.AddCommand(
+		NewListCommand(),
+		NewGetCommand(),
+		NewUpgradeCommand(),
+		NewUninstallCommand(),
+		NewLogsCommand(),
+		component.NewCommands(),
+		manager.NewCommands(),
+		registry.NewCommands(),
+		widget.NewCommands(),
+	)
+	return cmd
+}

--- a/cmd/cycloid/plugins/component/cmd.go
+++ b/cmd/cycloid/plugins/component/cmd.go
@@ -1,0 +1,22 @@
+package component
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/plugins/component/widget"
+)
+
+func NewCommands() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "component",
+		Aliases: []string{"components"},
+		Short:   "Manage component-plugin relations",
+	}
+
+	cmd.AddCommand(
+		NewListCommand(),
+		NewRelationSetCommand(),
+		widget.NewCommands(),
+	)
+	return cmd
+}

--- a/cmd/cycloid/plugins/component/list.go
+++ b/cmd/cycloid/plugins/component/list.go
@@ -28,9 +28,6 @@ func NewListCommand() *cobra.Command {
 }
 
 func listComponentPlugins(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
@@ -50,6 +47,9 @@ func listComponentPlugins(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
 
 	result, _, err := m.ListComponentPlugins(org, project, env, component)
 	return cyout.PrintWithOptions(cmd, result, err, "unable to list component plugins", printer.Options{})

--- a/cmd/cycloid/plugins/component/list.go
+++ b/cmd/cycloid/plugins/component/list.go
@@ -1,0 +1,56 @@
+package component
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Args:  cobra.NoArgs,
+		Short: "List plugins available to a component",
+		Example: `
+  cy plugin component list --project my-project --env production --component my-component
+`,
+		RunE: listComponentPlugins,
+	}
+
+	cyargs.AddProjectFlag(cmd)
+	cyargs.AddEnvFlag(cmd)
+	cyargs.AddComponentFlag(cmd)
+	return cmd
+}
+
+func listComponentPlugins(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	project, err := cyargs.GetProject(cmd)
+	if err != nil {
+		return err
+	}
+
+	env, err := cyargs.GetEnv(cmd)
+	if err != nil {
+		return err
+	}
+
+	component, err := cyargs.GetComponent(cmd)
+	if err != nil {
+		return err
+	}
+
+	result, _, err := m.ListComponentPlugins(org, project, env, component)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to list component plugins", printer.Options{})
+}

--- a/cmd/cycloid/plugins/component/relation_set.go
+++ b/cmd/cycloid/plugins/component/relation_set.go
@@ -31,9 +31,6 @@ func NewRelationSetCommand() *cobra.Command {
 }
 
 func setComponentPluginRelation(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
@@ -54,12 +51,15 @@ func setComponentPluginRelation(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	pluginInstallID, err := cyargs.ResolvePluginInstallID(org, args[0], m)
+	enabled, err := cmd.Flags().GetBool("enabled")
 	if err != nil {
 		return err
 	}
 
-	enabled, err := cmd.Flags().GetBool("enabled")
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	pluginInstallID, err := cyargs.ResolvePluginInstallID(org, args[0], m)
 	if err != nil {
 		return err
 	}

--- a/cmd/cycloid/plugins/component/relation_set.go
+++ b/cmd/cycloid/plugins/component/relation_set.go
@@ -1,0 +1,69 @@
+package component
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewRelationSetCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "relation-set <plugin-id-or-name>",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cyargs.CompletePluginInstallID,
+		Short:             "Enable or disable a plugin for a component",
+		Example: `
+  cy plugin component relation-set my-plugin --project my-project --env production --component my-component --enabled
+  cy plugin component relation-set 42 --project my-project --env production --component my-component --no-enabled
+`,
+		RunE: setComponentPluginRelation,
+	}
+
+	cyargs.AddProjectFlag(cmd)
+	cyargs.AddEnvFlag(cmd)
+	cyargs.AddComponentFlag(cmd)
+	cmd.Flags().Bool("enabled", true, "Enable or disable the plugin for the component")
+	return cmd
+}
+
+func setComponentPluginRelation(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	project, err := cyargs.GetProject(cmd)
+	if err != nil {
+		return err
+	}
+
+	env, err := cyargs.GetEnv(cmd)
+	if err != nil {
+		return err
+	}
+
+	component, err := cyargs.GetComponent(cmd)
+	if err != nil {
+		return err
+	}
+
+	pluginInstallID, err := cyargs.ResolvePluginInstallID(org, args[0], m)
+	if err != nil {
+		return err
+	}
+
+	enabled, err := cmd.Flags().GetBool("enabled")
+	if err != nil {
+		return err
+	}
+
+	result, _, err := m.SetComponentPluginRelation(org, project, env, component, pluginInstallID, enabled)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to set component plugin relation", printer.Options{})
+}

--- a/cmd/cycloid/plugins/component/widget/cmd.go
+++ b/cmd/cycloid/plugins/component/widget/cmd.go
@@ -1,0 +1,19 @@
+package widget
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewCommands() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "widget",
+		Aliases: []string{"widgets"},
+		Short:   "Manage component-level plugin widgets",
+	}
+
+	cmd.AddCommand(
+		NewListCommand(),
+		NewQueryCommand(),
+	)
+	return cmd
+}

--- a/cmd/cycloid/plugins/component/widget/list.go
+++ b/cmd/cycloid/plugins/component/widget/list.go
@@ -1,0 +1,56 @@
+package widget
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Args:  cobra.NoArgs,
+		Short: "List plugin widgets for a component",
+		Example: `
+  cy plugin component widget list --project my-project --env production --component my-component
+`,
+		RunE: listComponentPluginWidgets,
+	}
+
+	cyargs.AddProjectFlag(cmd)
+	cyargs.AddEnvFlag(cmd)
+	cyargs.AddComponentFlag(cmd)
+	return cmd
+}
+
+func listComponentPluginWidgets(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	project, err := cyargs.GetProject(cmd)
+	if err != nil {
+		return err
+	}
+
+	env, err := cyargs.GetEnv(cmd)
+	if err != nil {
+		return err
+	}
+
+	component, err := cyargs.GetComponent(cmd)
+	if err != nil {
+		return err
+	}
+
+	result, _, err := m.ListComponentPluginWidgets(org, project, env, component)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to list component plugin widgets", printer.Options{})
+}

--- a/cmd/cycloid/plugins/component/widget/list.go
+++ b/cmd/cycloid/plugins/component/widget/list.go
@@ -28,9 +28,6 @@ func NewListCommand() *cobra.Command {
 }
 
 func listComponentPluginWidgets(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
@@ -50,6 +47,9 @@ func listComponentPluginWidgets(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
 
 	result, _, err := m.ListComponentPluginWidgets(org, project, env, component)
 	return cyout.PrintWithOptions(cmd, result, err, "unable to list component plugin widgets", printer.Options{})

--- a/cmd/cycloid/plugins/component/widget/query.go
+++ b/cmd/cycloid/plugins/component/widget/query.go
@@ -31,9 +31,6 @@ func NewQueryCommand() *cobra.Command {
 }
 
 func queryComponentPluginWidget(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
@@ -53,6 +50,9 @@ func queryComponentPluginWidget(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
 
 	n, err := strconv.ParseUint(args[0], 10, 32)
 	if err != nil {

--- a/cmd/cycloid/plugins/component/widget/query.go
+++ b/cmd/cycloid/plugins/component/widget/query.go
@@ -1,0 +1,65 @@
+package widget
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewQueryCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "query <widget-id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Query data for a component-level plugin widget",
+		Example: `
+  cy plugin component widget query 42 --project my-project --env production --component my-component
+`,
+		RunE: queryComponentPluginWidget,
+	}
+
+	cyargs.AddProjectFlag(cmd)
+	cyargs.AddEnvFlag(cmd)
+	cyargs.AddComponentFlag(cmd)
+	return cmd
+}
+
+func queryComponentPluginWidget(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	project, err := cyargs.GetProject(cmd)
+	if err != nil {
+		return err
+	}
+
+	env, err := cyargs.GetEnv(cmd)
+	if err != nil {
+		return err
+	}
+
+	component, err := cyargs.GetComponent(cmd)
+	if err != nil {
+		return err
+	}
+
+	n, err := strconv.ParseUint(args[0], 10, 32)
+	if err != nil {
+		return fmt.Errorf("invalid widget-id %q: must be a positive integer", args[0])
+	}
+	widgetID := uint32(n)
+
+	result, _, err := m.QueryComponentPluginWidget(org, project, env, component, widgetID)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to query component plugin widget", printer.Options{})
+}

--- a/cmd/cycloid/plugins/get.go
+++ b/cmd/cycloid/plugins/get.go
@@ -25,13 +25,13 @@ func NewGetCommand() *cobra.Command {
 }
 
 func getPlugin(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
 
 	id, err := cyargs.ResolvePluginInstallID(org, args[0], m)
 	if err != nil {

--- a/cmd/cycloid/plugins/get.go
+++ b/cmd/cycloid/plugins/get.go
@@ -1,0 +1,43 @@
+package plugins
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewGetCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:               "get <id-or-name>",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cyargs.CompletePluginInstallID,
+		Short:             "Get a plugin install",
+		Example: `
+  cy plugin get 42
+  cy plugin get my-plugin
+`,
+		RunE: getPlugin,
+	}
+}
+
+func getPlugin(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	id, err := cyargs.ResolvePluginInstallID(org, args[0], m)
+	if err != nil {
+		return err
+	}
+
+	result, _, err := m.GetPlugin(org, id)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to get plugin", printer.Options{})
+}

--- a/cmd/cycloid/plugins/list.go
+++ b/cmd/cycloid/plugins/list.go
@@ -1,0 +1,37 @@
+package plugins
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Args:  cobra.NoArgs,
+		Short: "List installed plugins",
+		Example: `
+  # List installed plugins in my-org
+  cy plugin list --org my-org
+`,
+		RunE: listPlugins,
+	}
+}
+
+func listPlugins(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	result, _, err := m.ListPlugins(org)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to list plugins", printer.Options{})
+}

--- a/cmd/cycloid/plugins/list.go
+++ b/cmd/cycloid/plugins/list.go
@@ -24,13 +24,13 @@ func NewListCommand() *cobra.Command {
 }
 
 func listPlugins(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
 
 	result, _, err := m.ListPlugins(org)
 	return cyout.PrintWithOptions(cmd, result, err, "unable to list plugins", printer.Options{})

--- a/cmd/cycloid/plugins/logs.go
+++ b/cmd/cycloid/plugins/logs.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -48,6 +49,9 @@ func pluginLogs(cmd *cobra.Command, args []string) error {
 	interval, err := cmd.Flags().GetDuration("watch-interval")
 	if err != nil {
 		return err
+	}
+	if interval < 500*time.Millisecond {
+		return fmt.Errorf("--watch-interval must be at least 500ms, got %s", interval)
 	}
 
 	org, err := cyargs.GetOrg(cmd)

--- a/cmd/cycloid/plugins/logs.go
+++ b/cmd/cycloid/plugins/logs.go
@@ -1,0 +1,108 @@
+package plugins
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/client/models"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewLogsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "logs <id-or-name>",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cyargs.CompletePluginInstallID,
+		Short:             "Show deployment logs for a plugin install",
+		Long: `Show deployment and runtime logs for a plugin install.
+
+Use --watch (-w) to poll continuously for new log entries. Useful for
+following an ongoing deployment. Ctrl-C to stop.`,
+		Example: `
+  cy plugin logs 42
+  cy plugin logs my-plugin
+
+  # Follow logs as they arrive (poll every 5s)
+  cy plugin logs my-plugin --watch
+
+  # Custom polling interval
+  cy plugin logs my-plugin --watch --watch-interval 10s
+`,
+		RunE: pluginLogs,
+	}
+	cmd.Flags().BoolP("watch", "w", false, "Poll for new log entries until interrupted")
+	cmd.Flags().Duration("watch-interval", 5*time.Second, "Polling interval when --watch is set")
+	return cmd
+}
+
+func pluginLogs(cmd *cobra.Command, args []string) error {
+	watch, err := cmd.Flags().GetBool("watch")
+	if err != nil {
+		return err
+	}
+	interval, err := cmd.Flags().GetDuration("watch-interval")
+	if err != nil {
+		return err
+	}
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	id, err := cyargs.ResolvePluginInstallID(org, args[0], m)
+	if err != nil {
+		return err
+	}
+
+	if !watch {
+		result, _, err := m.ListPluginLogs(org, id)
+		return cyout.PrintWithOptions(cmd, result, err, "unable to get plugin logs", printer.Options{})
+	}
+
+	// Watch mode: poll and print only new entries.
+	var seenInstall, seenRuntime int
+	for {
+		result, _, err := m.ListPluginLogs(org, id)
+		if err != nil {
+			return cyout.PrintWithOptions(cmd, nil, err, "unable to get plugin logs", printer.Options{})
+		}
+		if result != nil {
+			newInstall, newRuntime := logSlicesDelta(result, seenInstall, seenRuntime)
+			if len(newInstall) > 0 || len(newRuntime) > 0 {
+				partial := &models.PluginLogs{
+					InstallLogs: newInstall,
+					RuntimeLogs: newRuntime,
+				}
+				if printErr := cyout.PrintWithOptions(cmd, partial, nil, "", printer.Options{}); printErr != nil {
+					return printErr
+				}
+				seenInstall += len(newInstall)
+				seenRuntime += len(newRuntime)
+			}
+		}
+		time.Sleep(interval)
+	}
+}
+
+// logSlicesDelta returns the unseen portion of each log slice.
+func logSlicesDelta(logs *models.PluginLogs, seenInstall, seenRuntime int) ([]*models.PluginInstallDeploymentLog, []*models.PluginInstallRuntimeLog) {
+	var newInstall []*models.PluginInstallDeploymentLog
+	var newRuntime []*models.PluginInstallRuntimeLog
+
+	if seenInstall < len(logs.InstallLogs) {
+		newInstall = logs.InstallLogs[seenInstall:]
+	}
+	if seenRuntime < len(logs.RuntimeLogs) {
+		newRuntime = logs.RuntimeLogs[seenRuntime:]
+	}
+	return newInstall, newRuntime
+}

--- a/cmd/cycloid/plugins/manager/accept.go
+++ b/cmd/cycloid/plugins/manager/accept.go
@@ -1,0 +1,47 @@
+package manager
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewAcceptCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:               "accept <id-or-name>",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cyargs.CompletePluginManagerID,
+		Short:             "Accept a plugin manager invitation",
+		Example: `
+  cy plugin manager accept 1
+  cy plugin manager accept my-manager
+`,
+		RunE: acceptPluginManager,
+	}
+}
+
+func acceptPluginManager(cmd *cobra.Command, args []string) error {
+	return updateInviteStatus(cmd, args, "accepted")
+}
+
+func updateInviteStatus(cmd *cobra.Command, args []string, status string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	id, err := cyargs.ResolvePluginManagerID(org, args[0], m)
+	if err != nil {
+		return err
+	}
+
+	result, _, err := m.UpdatePluginManager(org, id, status)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to update plugin manager", printer.Options{})
+}

--- a/cmd/cycloid/plugins/manager/accept.go
+++ b/cmd/cycloid/plugins/manager/accept.go
@@ -29,13 +29,13 @@ func acceptPluginManager(cmd *cobra.Command, args []string) error {
 }
 
 func updateInviteStatus(cmd *cobra.Command, args []string, status string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
 
 	id, err := cyargs.ResolvePluginManagerID(org, args[0], m)
 	if err != nil {

--- a/cmd/cycloid/plugins/manager/cmd.go
+++ b/cmd/cycloid/plugins/manager/cmd.go
@@ -1,0 +1,21 @@
+package manager
+
+import "github.com/spf13/cobra"
+
+func NewCommands() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "manager",
+		Aliases: []string{"managers"},
+		Short:   "Manage plugin managers",
+	}
+
+	cmd.AddCommand(
+		NewListCommand(),
+		NewGetCommand(),
+		NewCreateCommand(),
+		NewAcceptCommand(),
+		NewRejectCommand(),
+		NewDeleteCommand(),
+	)
+	return cmd
+}

--- a/cmd/cycloid/plugins/manager/create.go
+++ b/cmd/cycloid/plugins/manager/create.go
@@ -1,0 +1,88 @@
+package manager
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewCreateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Args:  cobra.NoArgs,
+		Short: "Invite a plugin manager to the organization",
+		Example: `
+  cy plugin manager create --name my-manager --url https://pm.example.com
+  cy plugin manager create --name my-manager --url https://pm.example.com --update
+`,
+		RunE: createPluginManager,
+	}
+
+	cmd.MarkFlagRequired(cyargs.AddNameFlag(cmd))
+	cyargs.AddURLFlag(cmd, "URL of the plugin manager instance (required)")
+	cmd.MarkFlagRequired("url")
+	cmd.Flags().Bool("update", false, "if the plugin manager already exists, return it without failing (idempotent create)")
+	return cmd
+}
+
+func createPluginManager(cmd *cobra.Command, args []string) error {
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, err := cyargs.GetName(cmd)
+	if err != nil {
+		return err
+	}
+
+	url, err := cyargs.GetURL(cmd)
+	if err != nil {
+		return errors.Wrap(err, "unable to get --url flag")
+	}
+
+	update, err := cmd.Flags().GetBool("update")
+	if err != nil {
+		return err
+	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	// Check if a manager with this name already exists.
+	existingID, resolveErr := cyargs.ResolvePluginManagerID(org, name, m)
+	exists := resolveErr == nil
+	if resolveErr != nil && !isNoMatchError(resolveErr) {
+		return cyout.PrintWithOptions(cmd, nil, resolveErr, "failed to check if plugin manager exists", printer.Options{})
+	}
+
+	if exists && !update {
+		return cyout.PrintWithOptions(cmd, nil,
+			fmt.Errorf("plugin manager %q already exists; use --update for an idempotent create", name),
+			"unable to create plugin manager", printer.Options{})
+	}
+
+	if exists {
+		// UpdatePluginManager only changes invite status, not name/url.
+		// With --update we return the existing manager without re-inviting.
+		result, _, err := m.GetPluginManager(org, existingID)
+		return cyout.PrintWithOptions(cmd, result, err, "unable to get existing plugin manager", printer.Options{})
+	}
+
+	result, _, err := m.CreatePluginManager(org, name, url)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to create plugin manager", printer.Options{})
+}
+
+// isNoMatchError returns true when err is the "no X found matching" sentinel
+// from cyargs.resolveUnique — indicating the resource simply does not exist yet.
+func isNoMatchError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "found matching")
+}

--- a/cmd/cycloid/plugins/manager/create.go
+++ b/cmd/cycloid/plugins/manager/create.go
@@ -2,7 +2,6 @@ package manager
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -26,9 +25,9 @@ func NewCreateCommand() *cobra.Command {
 		RunE: createPluginManager,
 	}
 
-	cmd.MarkFlagRequired(cyargs.AddNameFlag(cmd))
+	_ = cmd.MarkFlagRequired(cyargs.AddNameFlag(cmd))
 	cyargs.AddURLFlag(cmd, "URL of the plugin manager instance (required)")
-	cmd.MarkFlagRequired("url")
+	_ = cmd.MarkFlagRequired("url")
 	cmd.Flags().Bool("update", false, "if the plugin manager already exists, return it without failing (idempotent create)")
 	return cmd
 }
@@ -60,7 +59,7 @@ func createPluginManager(cmd *cobra.Command, args []string) error {
 	// Check if a manager with this name already exists.
 	existingID, resolveErr := cyargs.ResolvePluginManagerID(org, name, m)
 	exists := resolveErr == nil
-	if resolveErr != nil && !isNoMatchError(resolveErr) {
+	if resolveErr != nil && !cyargs.IsNoMatchError(resolveErr) {
 		return cyout.PrintWithOptions(cmd, nil, resolveErr, "failed to check if plugin manager exists", printer.Options{})
 	}
 
@@ -71,18 +70,13 @@ func createPluginManager(cmd *cobra.Command, args []string) error {
 	}
 
 	if exists {
-		// UpdatePluginManager only changes invite status, not name/url.
-		// With --update we return the existing manager without re-inviting.
+		if cmd.Flags().Changed("url") {
+			fmt.Fprintln(cmd.ErrOrStderr(), "note: --url cannot be changed via the API; existing URL is kept")
+		}
 		result, _, err := m.GetPluginManager(org, existingID)
 		return cyout.PrintWithOptions(cmd, result, err, "unable to get existing plugin manager", printer.Options{})
 	}
 
 	result, _, err := m.CreatePluginManager(org, name, url)
 	return cyout.PrintWithOptions(cmd, result, err, "unable to create plugin manager", printer.Options{})
-}
-
-// isNoMatchError returns true when err is the "no X found matching" sentinel
-// from cyargs.resolveUnique — indicating the resource simply does not exist yet.
-func isNoMatchError(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "found matching")
 }

--- a/cmd/cycloid/plugins/manager/delete.go
+++ b/cmd/cycloid/plugins/manager/delete.go
@@ -26,13 +26,13 @@ func NewDeleteCommand() *cobra.Command {
 }
 
 func deletePluginManager(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
 
 	for _, arg := range args {
 		id, err := cyargs.ResolvePluginManagerID(org, arg, m)

--- a/cmd/cycloid/plugins/manager/delete.go
+++ b/cmd/cycloid/plugins/manager/delete.go
@@ -1,0 +1,49 @@
+package manager
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewDeleteCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:               "delete <id-or-name>...",
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: cyargs.CompletePluginManagerID,
+		Short:             "Delete a plugin manager",
+		Example: `
+  cy plugin manager delete 1
+  cy plugin manager delete my-manager
+  cy plugin manager delete my-manager-a my-manager-b
+`,
+		RunE: deletePluginManager,
+	}
+}
+
+func deletePluginManager(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	for _, arg := range args {
+		id, err := cyargs.ResolvePluginManagerID(org, arg, m)
+		if err != nil {
+			return err
+		}
+
+		_, err = m.DeletePluginManager(org, id)
+		if err != nil {
+			return cyout.PrintWithOptions(cmd, nil, err, "unable to delete plugin manager "+arg, printer.Options{})
+		}
+	}
+	return cyout.PrintWithOptions(cmd, nil, nil, "", printer.Options{})
+}

--- a/cmd/cycloid/plugins/manager/get.go
+++ b/cmd/cycloid/plugins/manager/get.go
@@ -1,0 +1,43 @@
+package manager
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewGetCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:               "get <id-or-name>",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cyargs.CompletePluginManagerID,
+		Short:             "Get a plugin manager",
+		Example: `
+  cy plugin manager get 1
+  cy plugin manager get my-manager
+`,
+		RunE: getPluginManager,
+	}
+}
+
+func getPluginManager(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	id, err := cyargs.ResolvePluginManagerID(org, args[0], m)
+	if err != nil {
+		return err
+	}
+
+	result, _, err := m.GetPluginManager(org, id)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to get plugin manager", printer.Options{})
+}

--- a/cmd/cycloid/plugins/manager/get.go
+++ b/cmd/cycloid/plugins/manager/get.go
@@ -25,13 +25,13 @@ func NewGetCommand() *cobra.Command {
 }
 
 func getPluginManager(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
 
 	id, err := cyargs.ResolvePluginManagerID(org, args[0], m)
 	if err != nil {

--- a/cmd/cycloid/plugins/manager/list.go
+++ b/cmd/cycloid/plugins/manager/list.go
@@ -1,0 +1,36 @@
+package manager
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Args:  cobra.NoArgs,
+		Short: "List plugin managers",
+		Example: `
+  cy plugin manager list --org my-org
+`,
+		RunE: listPluginManagers,
+	}
+}
+
+func listPluginManagers(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	result, _, err := m.ListPluginManagers(org)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to list plugin managers", printer.Options{})
+}

--- a/cmd/cycloid/plugins/manager/list.go
+++ b/cmd/cycloid/plugins/manager/list.go
@@ -23,13 +23,13 @@ func NewListCommand() *cobra.Command {
 }
 
 func listPluginManagers(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
 
 	result, _, err := m.ListPluginManagers(org)
 	return cyout.PrintWithOptions(cmd, result, err, "unable to list plugin managers", printer.Options{})

--- a/cmd/cycloid/plugins/manager/reject.go
+++ b/cmd/cycloid/plugins/manager/reject.go
@@ -1,0 +1,25 @@
+package manager
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+)
+
+func NewRejectCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:               "reject <id-or-name>",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cyargs.CompletePluginManagerID,
+		Short:             "Reject a plugin manager invitation",
+		Example: `
+  cy plugin manager reject 1
+  cy plugin manager reject my-manager
+`,
+		RunE: rejectPluginManager,
+	}
+}
+
+func rejectPluginManager(cmd *cobra.Command, args []string) error {
+	return updateInviteStatus(cmd, args, "rejected")
+}

--- a/cmd/cycloid/plugins/registry/cmd.go
+++ b/cmd/cycloid/plugins/registry/cmd.go
@@ -1,0 +1,25 @@
+package registry
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/plugins/registry/plugin"
+)
+
+func NewCommands() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "registry",
+		Aliases: []string{"registries"},
+		Short:   "Manage plugin registries",
+	}
+
+	cmd.AddCommand(
+		NewListCommand(),
+		NewGetCommand(),
+		NewCreateCommand(),
+		NewUpdateCommand(),
+		NewDeleteCommand(),
+		plugin.NewCommands(),
+	)
+	return cmd
+}

--- a/cmd/cycloid/plugins/registry/delete.go
+++ b/cmd/cycloid/plugins/registry/delete.go
@@ -26,13 +26,13 @@ func NewDeleteCommand() *cobra.Command {
 }
 
 func deletePluginRegistry(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
 
 	for _, arg := range args {
 		id, err := cyargs.ResolvePluginRegistryID(org, arg, m)

--- a/cmd/cycloid/plugins/registry/delete.go
+++ b/cmd/cycloid/plugins/registry/delete.go
@@ -1,0 +1,49 @@
+package registry
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewDeleteCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:               "delete <id-or-name-or-url>...",
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: cyargs.CompletePluginRegistryID,
+		Short:             "Delete a plugin registry",
+		Example: `
+  cy plugin registry delete 1
+  cy plugin registry delete my-registry
+  cy plugin registry delete my-registry-a my-registry-b
+`,
+		RunE: deletePluginRegistry,
+	}
+}
+
+func deletePluginRegistry(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	for _, arg := range args {
+		id, err := cyargs.ResolvePluginRegistryID(org, arg, m)
+		if err != nil {
+			return err
+		}
+
+		_, err = m.DeletePluginRegistry(org, id)
+		if err != nil {
+			return cyout.PrintWithOptions(cmd, nil, err, "unable to delete plugin registry "+arg, printer.Options{})
+		}
+	}
+	return cyout.PrintWithOptions(cmd, nil, nil, "", printer.Options{})
+}

--- a/cmd/cycloid/plugins/registry/get.go
+++ b/cmd/cycloid/plugins/registry/get.go
@@ -26,13 +26,13 @@ func NewGetCommand() *cobra.Command {
 }
 
 func getPluginRegistry(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
 
 	id, err := cyargs.ResolvePluginRegistryID(org, args[0], m)
 	if err != nil {

--- a/cmd/cycloid/plugins/registry/get.go
+++ b/cmd/cycloid/plugins/registry/get.go
@@ -1,0 +1,44 @@
+package registry
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewGetCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:               "get <id-or-name-or-url>",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cyargs.CompletePluginRegistryID,
+		Short:             "Get a plugin registry",
+		Example: `
+  cy plugin registry get 1
+  cy plugin registry get my-registry
+  cy plugin registry get https://registry.example.com
+`,
+		RunE: getPluginRegistry,
+	}
+}
+
+func getPluginRegistry(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	id, err := cyargs.ResolvePluginRegistryID(org, args[0], m)
+	if err != nil {
+		return err
+	}
+
+	result, _, err := m.GetPluginRegistry(org, id)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to get plugin registry", printer.Options{})
+}

--- a/cmd/cycloid/plugins/registry/list.go
+++ b/cmd/cycloid/plugins/registry/list.go
@@ -23,13 +23,13 @@ func NewListCommand() *cobra.Command {
 }
 
 func listPluginRegistries(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
 
 	result, _, err := m.ListPluginRegistries(org)
 	return cyout.PrintWithOptions(cmd, result, err, "unable to list plugin registries", printer.Options{})

--- a/cmd/cycloid/plugins/registry/list.go
+++ b/cmd/cycloid/plugins/registry/list.go
@@ -1,0 +1,36 @@
+package registry
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Args:  cobra.NoArgs,
+		Short: "List plugin registries",
+		Example: `
+  cy plugin registry list --org my-org
+`,
+		RunE: listPluginRegistries,
+	}
+}
+
+func listPluginRegistries(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	result, _, err := m.ListPluginRegistries(org)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to list plugin registries", printer.Options{})
+}

--- a/cmd/cycloid/plugins/registry/plugin/cmd.go
+++ b/cmd/cycloid/plugins/registry/plugin/cmd.go
@@ -1,0 +1,25 @@
+package plugin
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/plugins/registry/plugin/version"
+)
+
+func NewCommands() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "plugin",
+		Aliases: []string{"plugins"},
+		Short:   "Manage plugins within a registry",
+	}
+
+	cmd.AddCommand(
+		NewListCommand(),
+		NewGetCommand(),
+		NewCreateCommand(),
+		NewUpdateCommand(),
+		NewDeleteCommand(),
+		version.NewCommands(),
+	)
+	return cmd
+}

--- a/cmd/cycloid/plugins/registry/plugin/create.go
+++ b/cmd/cycloid/plugins/registry/plugin/create.go
@@ -2,7 +2,6 @@ package plugin
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -26,7 +25,7 @@ func NewCreateCommand() *cobra.Command {
 		RunE: createRegistryPlugin,
 	}
 
-	cmd.MarkFlagRequired(cyargs.AddNameFlag(cmd))
+	_ = cmd.MarkFlagRequired(cyargs.AddNameFlag(cmd))
 	cmd.Flags().Bool("update", false, "update the plugin if it already exists in the registry")
 	return cmd
 }
@@ -58,7 +57,7 @@ func createRegistryPlugin(cmd *cobra.Command, args []string) error {
 	// Check if a plugin with this name already exists in the registry.
 	existingID, resolveErr := cyargs.ResolveRegistryPluginID(org, registryID, name, m)
 	exists := resolveErr == nil
-	if resolveErr != nil && !isNoMatchError(resolveErr) {
+	if resolveErr != nil && !cyargs.IsNoMatchError(resolveErr) {
 		return cyout.PrintWithOptions(cmd, nil, resolveErr, "failed to check if registry plugin exists", printer.Options{})
 	}
 
@@ -75,10 +74,4 @@ func createRegistryPlugin(cmd *cobra.Command, args []string) error {
 
 	result, _, err := m.CreateRegistryPlugin(org, registryID, name)
 	return cyout.PrintWithOptions(cmd, result, err, "unable to create registry plugin", printer.Options{})
-}
-
-// isNoMatchError returns true when err is the "no X found matching" sentinel
-// from cyargs.resolveUnique — indicating the resource simply does not exist yet.
-func isNoMatchError(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "found matching")
 }

--- a/cmd/cycloid/plugins/registry/plugin/create.go
+++ b/cmd/cycloid/plugins/registry/plugin/create.go
@@ -1,0 +1,84 @@
+package plugin
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewCreateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "create <registry-id-or-name>",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cyargs.CompletePluginRegistryID,
+		Short:             "Create a plugin in a registry",
+		Example: `
+  cy plugin registry plugin create my-registry --name my-plugin
+  cy plugin registry plugin create my-registry --name my-plugin --update
+`,
+		RunE: createRegistryPlugin,
+	}
+
+	cmd.MarkFlagRequired(cyargs.AddNameFlag(cmd))
+	cmd.Flags().Bool("update", false, "update the plugin if it already exists in the registry")
+	return cmd
+}
+
+func createRegistryPlugin(cmd *cobra.Command, args []string) error {
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	name, err := cyargs.GetName(cmd)
+	if err != nil {
+		return err
+	}
+
+	update, err := cmd.Flags().GetBool("update")
+	if err != nil {
+		return err
+	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	registryID, err := cyargs.ResolvePluginRegistryID(org, args[0], m)
+	if err != nil {
+		return err
+	}
+
+	// Check if a plugin with this name already exists in the registry.
+	existingID, resolveErr := cyargs.ResolveRegistryPluginID(org, registryID, name, m)
+	exists := resolveErr == nil
+	if resolveErr != nil && !isNoMatchError(resolveErr) {
+		return cyout.PrintWithOptions(cmd, nil, resolveErr, "failed to check if registry plugin exists", printer.Options{})
+	}
+
+	if exists && !update {
+		return cyout.PrintWithOptions(cmd, nil,
+			fmt.Errorf("plugin %q already exists in this registry; use --update or `cy plugin registry plugin update`", name),
+			"unable to create registry plugin", printer.Options{})
+	}
+
+	if exists {
+		result, _, err := m.UpdateRegistryPlugin(org, registryID, existingID, name)
+		return cyout.PrintWithOptions(cmd, result, err, "unable to update registry plugin", printer.Options{})
+	}
+
+	result, _, err := m.CreateRegistryPlugin(org, registryID, name)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to create registry plugin", printer.Options{})
+}
+
+// isNoMatchError returns true when err is the "no X found matching" sentinel
+// from cyargs.resolveUnique — indicating the resource simply does not exist yet.
+func isNoMatchError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "found matching")
+}

--- a/cmd/cycloid/plugins/registry/plugin/delete.go
+++ b/cmd/cycloid/plugins/registry/plugin/delete.go
@@ -24,13 +24,13 @@ func NewDeleteCommand() *cobra.Command {
 }
 
 func deleteRegistryPlugin(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
 
 	registryID, err := cyargs.ResolvePluginRegistryID(org, args[0], m)
 	if err != nil {

--- a/cmd/cycloid/plugins/registry/plugin/delete.go
+++ b/cmd/cycloid/plugins/registry/plugin/delete.go
@@ -1,0 +1,47 @@
+package plugin
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewDeleteCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:               "delete <registry-id-or-name> <plugin-id-or-name>",
+		Args:              cobra.ExactArgs(2),
+		ValidArgsFunction: cyargs.CompleteRegistryPluginID,
+		Short:             "Delete a plugin from a registry",
+		Example: `
+  cy plugin registry plugin delete my-registry my-plugin
+`,
+		RunE: deleteRegistryPlugin,
+	}
+}
+
+func deleteRegistryPlugin(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	registryID, err := cyargs.ResolvePluginRegistryID(org, args[0], m)
+	if err != nil {
+		return err
+	}
+
+	pluginID, err := cyargs.ResolveRegistryPluginID(org, registryID, args[1], m)
+	if err != nil {
+		return err
+	}
+
+	_, err = m.DeleteRegistryPlugin(org, registryID, pluginID)
+	return cyout.PrintWithOptions(cmd, nil, err, "unable to delete registry plugin", printer.Options{})
+}

--- a/cmd/cycloid/plugins/registry/plugin/get.go
+++ b/cmd/cycloid/plugins/registry/plugin/get.go
@@ -1,0 +1,48 @@
+package plugin
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewGetCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:               "get <registry-id-or-name> <plugin-id-or-name>",
+		Args:              cobra.ExactArgs(2),
+		ValidArgsFunction: cyargs.CompleteRegistryPluginID,
+		Short:             "Get a plugin from a registry",
+		Example: `
+  cy plugin registry plugin get my-registry my-plugin
+  cy plugin registry plugin get 1 42
+`,
+		RunE: getRegistryPlugin,
+	}
+}
+
+func getRegistryPlugin(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	registryID, err := cyargs.ResolvePluginRegistryID(org, args[0], m)
+	if err != nil {
+		return err
+	}
+
+	pluginID, err := cyargs.ResolveRegistryPluginID(org, registryID, args[1], m)
+	if err != nil {
+		return err
+	}
+
+	result, _, err := m.GetRegistryPlugin(org, registryID, pluginID)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to get registry plugin", printer.Options{})
+}

--- a/cmd/cycloid/plugins/registry/plugin/get.go
+++ b/cmd/cycloid/plugins/registry/plugin/get.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"github.com/cycloidio/cycloid-cli/client/models"
 	"github.com/spf13/cobra"
 
 	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
@@ -11,38 +12,61 @@ import (
 )
 
 func NewGetCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:               "get <registry-id-or-name> <plugin-id-or-name>",
-		Args:              cobra.ExactArgs(2),
-		ValidArgsFunction: cyargs.CompleteRegistryPluginID,
-		Short:             "Get a plugin from a registry",
+	cmd := &cobra.Command{
+		Use:               "get <plugin-id-or-name>...",
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: cyargs.CompletePluginIDFromRegistryFlag,
+		Short:             "Get one or more plugins from a registry",
 		Example: `
-  cy plugin registry plugin get my-registry my-plugin
-  cy plugin registry plugin get 1 42
+  cy plugin registry plugin get my-plugin --registry my-registry
+  cy plugin registry plugin get plugin-a plugin-b --registry my-registry
+  cy plugin registry plugin get 42 --registry 1
 `,
 		RunE: getRegistryPlugin,
 	}
+	_ = cmd.MarkFlagRequired(cyargs.AddRegistryFlag(cmd))
+	return cmd
 }
 
 func getRegistryPlugin(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
 
-	registryID, err := cyargs.ResolvePluginRegistryID(org, args[0], m)
+	registryStr, err := cyargs.GetRegistry(cmd)
 	if err != nil {
 		return err
 	}
 
-	pluginID, err := cyargs.ResolveRegistryPluginID(org, registryID, args[1], m)
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	registryID, err := cyargs.ResolvePluginRegistryID(org, registryStr, m)
 	if err != nil {
 		return err
 	}
 
-	result, _, err := m.GetRegistryPlugin(org, registryID, pluginID)
-	return cyout.PrintWithOptions(cmd, result, err, "unable to get registry plugin", printer.Options{})
+	if len(args) == 1 {
+		pluginID, err := cyargs.ResolveRegistryPluginID(org, registryID, args[0], m)
+		if err != nil {
+			return err
+		}
+		result, _, err := m.GetRegistryPlugin(org, registryID, pluginID)
+		return cyout.PrintWithOptions(cmd, result, err, "unable to get registry plugin", printer.Options{})
+	}
+
+	results := make([]*models.Plugin, 0, len(args))
+	for _, nameOrID := range args {
+		pluginID, err := cyargs.ResolveRegistryPluginID(org, registryID, nameOrID, m)
+		if err != nil {
+			return cyout.PrintWithOptions(cmd, nil, err, "unable to resolve plugin "+nameOrID, printer.Options{})
+		}
+		p, _, err := m.GetRegistryPlugin(org, registryID, pluginID)
+		if err != nil {
+			return cyout.PrintWithOptions(cmd, nil, err, "unable to get plugin "+nameOrID, printer.Options{})
+		}
+		results = append(results, p)
+	}
+	return cyout.PrintWithOptions(cmd, results, nil, "", printer.Options{})
 }

--- a/cmd/cycloid/plugins/registry/plugin/list.go
+++ b/cmd/cycloid/plugins/registry/plugin/list.go
@@ -1,0 +1,43 @@
+package plugin
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:               "list <registry-id-or-name>",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cyargs.CompletePluginRegistryID,
+		Short:             "List plugins in a registry",
+		Example: `
+  cy plugin registry plugin list my-registry
+  cy plugin registry plugin list 1
+`,
+		RunE: listRegistryPlugins,
+	}
+}
+
+func listRegistryPlugins(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	registryID, err := cyargs.ResolvePluginRegistryID(org, args[0], m)
+	if err != nil {
+		return err
+	}
+
+	result, _, err := m.ListRegistryPlugins(org, registryID)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to list registry plugins", printer.Options{})
+}

--- a/cmd/cycloid/plugins/registry/plugin/list.go
+++ b/cmd/cycloid/plugins/registry/plugin/list.go
@@ -25,13 +25,13 @@ func NewListCommand() *cobra.Command {
 }
 
 func listRegistryPlugins(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
 
 	registryID, err := cyargs.ResolvePluginRegistryID(org, args[0], m)
 	if err != nil {

--- a/cmd/cycloid/plugins/registry/plugin/update.go
+++ b/cmd/cycloid/plugins/registry/plugin/update.go
@@ -23,18 +23,23 @@ func NewUpdateCommand() *cobra.Command {
 		RunE: updateRegistryPlugin,
 	}
 
-	cmd.MarkFlagRequired(cyargs.AddNameFlag(cmd))
+	_ = cmd.MarkFlagRequired(cyargs.AddNameFlag(cmd))
 	return cmd
 }
 
 func updateRegistryPlugin(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
+
+	name, err := cyargs.GetName(cmd)
+	if err != nil {
+		return err
+	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
 
 	registryID, err := cyargs.ResolvePluginRegistryID(org, args[0], m)
 	if err != nil {
@@ -42,11 +47,6 @@ func updateRegistryPlugin(cmd *cobra.Command, args []string) error {
 	}
 
 	pluginID, err := cyargs.ResolveRegistryPluginID(org, registryID, args[1], m)
-	if err != nil {
-		return err
-	}
-
-	name, err := cyargs.GetName(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/cycloid/plugins/registry/plugin/update.go
+++ b/cmd/cycloid/plugins/registry/plugin/update.go
@@ -1,0 +1,56 @@
+package plugin
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewUpdateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "update <registry-id-or-name> <plugin-id-or-name>",
+		Args:              cobra.ExactArgs(2),
+		ValidArgsFunction: cyargs.CompleteRegistryPluginID,
+		Short:             "Update a plugin in a registry",
+		Example: `
+  cy plugin registry plugin update my-registry my-plugin --name new-name
+  cy plugin registry plugin update 1 42 --name renamed
+`,
+		RunE: updateRegistryPlugin,
+	}
+
+	cmd.MarkFlagRequired(cyargs.AddNameFlag(cmd))
+	return cmd
+}
+
+func updateRegistryPlugin(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	registryID, err := cyargs.ResolvePluginRegistryID(org, args[0], m)
+	if err != nil {
+		return err
+	}
+
+	pluginID, err := cyargs.ResolveRegistryPluginID(org, registryID, args[1], m)
+	if err != nil {
+		return err
+	}
+
+	name, err := cyargs.GetName(cmd)
+	if err != nil {
+		return err
+	}
+
+	result, _, err := m.UpdateRegistryPlugin(org, registryID, pluginID, name)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to update registry plugin", printer.Options{})
+}

--- a/cmd/cycloid/plugins/registry/plugin/version/cmd.go
+++ b/cmd/cycloid/plugins/registry/plugin/version/cmd.go
@@ -1,0 +1,22 @@
+package version
+
+import "github.com/spf13/cobra"
+
+func NewCommands() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "version",
+		Aliases: []string{"versions"},
+		Short:   "Manage plugin versions within a registry",
+	}
+
+	cmd.AddCommand(
+		NewListCommand(),
+		NewGetCommand(),
+		NewPublishCommand(),
+		NewDeleteCommand(),
+		NewInstallCommand(),
+		NewLogsCommand(),
+		NewRetryCommand(),
+	)
+	return cmd
+}

--- a/cmd/cycloid/plugins/registry/plugin/version/delete.go
+++ b/cmd/cycloid/plugins/registry/plugin/version/delete.go
@@ -11,33 +11,36 @@ import (
 )
 
 func NewDeleteCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:               "delete <registry> <plugin> <version-id>",
-		Args:              cobra.ExactArgs(3),
-		ValidArgsFunction: cyargs.CompleteRegistryPluginID,
+	cmd := &cobra.Command{
+		Use:               "delete <version-id>",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cyargs.CompletePluginVersionID,
 		Short:             "Delete a plugin version",
 		Example: `
-  cy plugin registry plugin version delete my-registry my-plugin 7
+  cy plugin registry plugin version delete 7 --registry my-registry --plugin my-plugin
 `,
 		RunE: deleteVersion,
 	}
+	_ = cmd.MarkFlagRequired(cyargs.AddRegistryFlag(cmd))
+	_ = cmd.MarkFlagRequired(cyargs.AddPluginFlag(cmd))
+	return cmd
 }
 
 func deleteVersion(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
 
-	registryID, pluginID, err := resolveRegistryAndPlugin(org, args, m)
+	versionID, err := parseVersionID(args[0])
 	if err != nil {
 		return err
 	}
 
-	versionID, err := parseVersionID(args[2])
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	registryID, pluginID, err := resolveRegistryAndPlugin(org, cmd, m)
 	if err != nil {
 		return err
 	}

--- a/cmd/cycloid/plugins/registry/plugin/version/delete.go
+++ b/cmd/cycloid/plugins/registry/plugin/version/delete.go
@@ -1,0 +1,47 @@
+package version
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewDeleteCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:               "delete <registry> <plugin> <version-id>",
+		Args:              cobra.ExactArgs(3),
+		ValidArgsFunction: cyargs.CompleteRegistryPluginID,
+		Short:             "Delete a plugin version",
+		Example: `
+  cy plugin registry plugin version delete my-registry my-plugin 7
+`,
+		RunE: deleteVersion,
+	}
+}
+
+func deleteVersion(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	registryID, pluginID, err := resolveRegistryAndPlugin(org, args, m)
+	if err != nil {
+		return err
+	}
+
+	versionID, err := parseVersionID(args[2])
+	if err != nil {
+		return err
+	}
+
+	_, err = m.DeletePluginVersion(org, registryID, pluginID, versionID)
+	return cyout.PrintWithOptions(cmd, nil, err, "unable to delete plugin version", printer.Options{})
+}

--- a/cmd/cycloid/plugins/registry/plugin/version/get.go
+++ b/cmd/cycloid/plugins/registry/plugin/version/get.go
@@ -11,33 +11,36 @@ import (
 )
 
 func NewGetCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:               "get <registry> <plugin> <version-id>",
-		Args:              cobra.ExactArgs(3),
-		ValidArgsFunction: cyargs.CompleteRegistryPluginID,
+	cmd := &cobra.Command{
+		Use:               "get <version-id>",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cyargs.CompletePluginVersionID,
 		Short:             "Get a specific plugin version",
 		Example: `
-  cy plugin registry plugin version get my-registry my-plugin 7
+  cy plugin registry plugin version get 7 --registry my-registry --plugin my-plugin
 `,
 		RunE: getVersion,
 	}
+	_ = cmd.MarkFlagRequired(cyargs.AddRegistryFlag(cmd))
+	_ = cmd.MarkFlagRequired(cyargs.AddPluginFlag(cmd))
+	return cmd
 }
 
 func getVersion(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
 
-	registryID, pluginID, err := resolveRegistryAndPlugin(org, args, m)
+	versionID, err := parseVersionID(args[0])
 	if err != nil {
 		return err
 	}
 
-	versionID, err := parseVersionID(args[2])
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	registryID, pluginID, err := resolveRegistryAndPlugin(org, cmd, m)
 	if err != nil {
 		return err
 	}

--- a/cmd/cycloid/plugins/registry/plugin/version/get.go
+++ b/cmd/cycloid/plugins/registry/plugin/version/get.go
@@ -1,0 +1,47 @@
+package version
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewGetCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:               "get <registry> <plugin> <version-id>",
+		Args:              cobra.ExactArgs(3),
+		ValidArgsFunction: cyargs.CompleteRegistryPluginID,
+		Short:             "Get a specific plugin version",
+		Example: `
+  cy plugin registry plugin version get my-registry my-plugin 7
+`,
+		RunE: getVersion,
+	}
+}
+
+func getVersion(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	registryID, pluginID, err := resolveRegistryAndPlugin(org, args, m)
+	if err != nil {
+		return err
+	}
+
+	versionID, err := parseVersionID(args[2])
+	if err != nil {
+		return err
+	}
+
+	result, _, err := m.GetPluginVersion(org, registryID, pluginID, versionID)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to get plugin version", printer.Options{})
+}

--- a/cmd/cycloid/plugins/registry/plugin/version/helpers.go
+++ b/cmd/cycloid/plugins/registry/plugin/version/helpers.go
@@ -1,0 +1,31 @@
+package version
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+)
+
+// resolveRegistryAndPlugin resolves args[0] (registry) and args[1] (plugin) to their numeric IDs.
+func resolveRegistryAndPlugin(org string, args []string, m middleware.Middleware) (registryID, pluginID uint32, err error) {
+	registryID, err = cyargs.ResolvePluginRegistryID(org, args[0], m)
+	if err != nil {
+		return 0, 0, err
+	}
+	pluginID, err = cyargs.ResolveRegistryPluginID(org, registryID, args[1], m)
+	if err != nil {
+		return 0, 0, err
+	}
+	return registryID, pluginID, nil
+}
+
+// parseVersionID parses a version ID string to uint32.
+func parseVersionID(s string) (uint32, error) {
+	n, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid version ID %q: must be a positive integer", s)
+	}
+	return uint32(n), nil
+}

--- a/cmd/cycloid/plugins/registry/plugin/version/helpers.go
+++ b/cmd/cycloid/plugins/registry/plugin/version/helpers.go
@@ -4,17 +4,27 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/spf13/cobra"
+
 	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
 	"github.com/cycloidio/cycloid-cli/internal/cyargs"
 )
 
-// resolveRegistryAndPlugin resolves args[0] (registry) and args[1] (plugin) to their numeric IDs.
-func resolveRegistryAndPlugin(org string, args []string, m middleware.Middleware) (registryID, pluginID uint32, err error) {
-	registryID, err = cyargs.ResolvePluginRegistryID(org, args[0], m)
+// resolveRegistryAndPlugin resolves --registry and --plugin flags to their numeric IDs.
+func resolveRegistryAndPlugin(org string, cmd *cobra.Command, m middleware.Middleware) (registryID, pluginID uint32, err error) {
+	registryStr, err := cyargs.GetRegistry(cmd)
 	if err != nil {
 		return 0, 0, err
 	}
-	pluginID, err = cyargs.ResolveRegistryPluginID(org, registryID, args[1], m)
+	registryID, err = cyargs.ResolvePluginRegistryID(org, registryStr, m)
+	if err != nil {
+		return 0, 0, err
+	}
+	pluginStr, err := cyargs.GetPlugin(cmd)
+	if err != nil {
+		return 0, 0, err
+	}
+	pluginID, err = cyargs.ResolveRegistryPluginID(org, registryID, pluginStr, m)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/cmd/cycloid/plugins/registry/plugin/version/install.go
+++ b/cmd/cycloid/plugins/registry/plugin/version/install.go
@@ -1,7 +1,7 @@
 package version
 
 import (
-	"strings"
+	"net/http"
 
 	"github.com/spf13/cobra"
 
@@ -14,9 +14,9 @@ import (
 
 func NewInstallCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "install <registry> <plugin> <version-id>",
-		Args:              cobra.ExactArgs(3),
-		ValidArgsFunction: cyargs.CompleteRegistryPluginID,
+		Use:               "install <version-id>",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cyargs.CompletePluginVersionID,
 		Short:             "Install a plugin version into your organization",
 		Long: `Install a specific plugin version into your organization.
 
@@ -24,7 +24,7 @@ This deploys the plugin container via the plugin manager and registers the
 plugin as a running install in your org. The version's manifest declares which
 configuration fields are required — check them first with:
 
-  cy plugin registry plugin version get <registry> <plugin> <version-id>
+  cy plugin registry plugin version get <version-id> --registry <registry> --plugin <plugin>
 
 Configuration is supplied as key=value pairs (--config) or as a JSON file
 (--config-file). Both can be combined: the file provides base values and
@@ -44,31 +44,32 @@ installed, the command retries the installation instead of failing. Safe to use
 in CI/CD pipelines where the command may run more than once.`,
 		Example: `
   # List versions to find the one you want
-  cy plugin registry plugin version list my-registry my-plugin
+  cy plugin registry plugin version list --registry my-registry --plugin my-plugin
 
   # Check what configuration fields a version requires
-  cy plugin registry plugin version get my-registry my-plugin 7
+  cy plugin registry plugin version get 7 --registry my-registry --plugin my-plugin
 
   # Install with inline configuration
-  cy plugin registry plugin version install my-registry my-plugin 7 \
+  cy plugin registry plugin version install 7 \
+    --registry my-registry --plugin my-plugin \
     --config api_url=https://api.example.com \
     --config api_token=secret
 
   # Install with a config file (non-secret values committed to repo)
-  cy plugin registry plugin version install my-registry my-plugin 7 \
+  cy plugin registry plugin version install 7 \
+    --registry my-registry --plugin my-plugin \
     --config-file ./plugin-config.json \
     --config api_token=secret
 
-  # Pin to a specific version in CI/CD (reproducible installs)
-  cy plugin registry plugin version install my-registry my-plugin 7 \
-    --config-file ./plugin-config.json
-
   # Idempotent install (safe to run in CI/CD pipelines)
-  cy plugin registry plugin version install my-registry my-plugin 7 \
+  cy plugin registry plugin version install 7 \
+    --registry my-registry --plugin my-plugin \
     --config-file ./plugin-config.json --retry
 `,
 		RunE: installVersion,
 	}
+	_ = cmd.MarkFlagRequired(cyargs.AddRegistryFlag(cmd))
+	_ = cmd.MarkFlagRequired(cyargs.AddPluginFlag(cmd))
 	cyargs.AddPluginConfigFlags(cmd)
 	cmd.Flags().Bool("retry", false, "If the plugin version is already installed, retry the installation instead of failing")
 	return cmd
@@ -85,15 +86,15 @@ func installVersion(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
-	registryID, pluginID, err := resolveRegistryAndPlugin(org, args, m)
+	versionID, err := parseVersionID(args[0])
 	if err != nil {
 		return err
 	}
 
-	versionID, err := parseVersionID(args[2])
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	registryID, pluginID, err := resolveRegistryAndPlugin(org, cmd, m)
 	if err != nil {
 		return err
 	}
@@ -103,8 +104,8 @@ func installVersion(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	_, installErr := m.InstallPluginVersion(org, registryID, pluginID, versionID, configuration)
-	if installErr != nil && retry && strings.Contains(strings.ToLower(installErr.Error()), "already") {
+	resp, installErr := m.InstallPluginVersion(org, registryID, pluginID, versionID, configuration)
+	if installErr != nil && retry && resp != nil && resp.StatusCode == http.StatusConflict {
 		_, installErr = m.RetryPluginVersion(org, registryID, pluginID, versionID)
 	}
 	return cyout.PrintWithOptions(cmd, nil, installErr, "unable to trigger plugin version install", printer.Options{})

--- a/cmd/cycloid/plugins/registry/plugin/version/install.go
+++ b/cmd/cycloid/plugins/registry/plugin/version/install.go
@@ -1,0 +1,111 @@
+package version
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewInstallCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "install <registry> <plugin> <version-id>",
+		Args:              cobra.ExactArgs(3),
+		ValidArgsFunction: cyargs.CompleteRegistryPluginID,
+		Short:             "Install a plugin version into your organization",
+		Long: `Install a specific plugin version into your organization.
+
+This deploys the plugin container via the plugin manager and registers the
+plugin as a running install in your org. The version's manifest declares which
+configuration fields are required — check them first with:
+
+  cy plugin registry plugin version get <registry> <plugin> <version-id>
+
+Configuration is supplied as key=value pairs (--config) or as a JSON file
+(--config-file). Both can be combined: the file provides base values and
+--config flags override individual keys. This is useful in CI/CD pipelines
+where non-secret config lives in a committed file and secrets are injected
+at runtime.
+
+Once installed, the plugin appears in 'cy plugin list' and its widgets become
+available under 'cy plugin widget list'. Use 'cy plugin upgrade' to change
+version or update configuration. Use 'cy plugin uninstall' to remove it.
+
+A plugin manager must be configured and accepted before running this command.
+See 'cy plugin manager --help'.
+
+Use --retry to make the install idempotent: if the plugin version is already
+installed, the command retries the installation instead of failing. Safe to use
+in CI/CD pipelines where the command may run more than once.`,
+		Example: `
+  # List versions to find the one you want
+  cy plugin registry plugin version list my-registry my-plugin
+
+  # Check what configuration fields a version requires
+  cy plugin registry plugin version get my-registry my-plugin 7
+
+  # Install with inline configuration
+  cy plugin registry plugin version install my-registry my-plugin 7 \
+    --config api_url=https://api.example.com \
+    --config api_token=secret
+
+  # Install with a config file (non-secret values committed to repo)
+  cy plugin registry plugin version install my-registry my-plugin 7 \
+    --config-file ./plugin-config.json \
+    --config api_token=secret
+
+  # Pin to a specific version in CI/CD (reproducible installs)
+  cy plugin registry plugin version install my-registry my-plugin 7 \
+    --config-file ./plugin-config.json
+
+  # Idempotent install (safe to run in CI/CD pipelines)
+  cy plugin registry plugin version install my-registry my-plugin 7 \
+    --config-file ./plugin-config.json --retry
+`,
+		RunE: installVersion,
+	}
+	cyargs.AddPluginConfigFlags(cmd)
+	cmd.Flags().Bool("retry", false, "If the plugin version is already installed, retry the installation instead of failing")
+	return cmd
+}
+
+func installVersion(cmd *cobra.Command, args []string) error {
+	retry, err := cmd.Flags().GetBool("retry")
+	if err != nil {
+		return err
+	}
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	registryID, pluginID, err := resolveRegistryAndPlugin(org, args, m)
+	if err != nil {
+		return err
+	}
+
+	versionID, err := parseVersionID(args[2])
+	if err != nil {
+		return err
+	}
+
+	configuration, err := cyargs.GetPluginConfig(cmd)
+	if err != nil {
+		return err
+	}
+
+	_, installErr := m.InstallPluginVersion(org, registryID, pluginID, versionID, configuration)
+	if installErr != nil && retry && strings.Contains(strings.ToLower(installErr.Error()), "already") {
+		_, installErr = m.RetryPluginVersion(org, registryID, pluginID, versionID)
+	}
+	return cyout.PrintWithOptions(cmd, nil, installErr, "unable to trigger plugin version install", printer.Options{})
+}

--- a/cmd/cycloid/plugins/registry/plugin/version/list.go
+++ b/cmd/cycloid/plugins/registry/plugin/version/list.go
@@ -11,28 +11,31 @@ import (
 )
 
 func NewListCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:               "list <registry> <plugin>",
-		Args:              cobra.ExactArgs(2),
-		ValidArgsFunction: cyargs.CompleteRegistryPluginID,
+	cmd := &cobra.Command{
+		Use:               "list",
+		Args:              cobra.NoArgs,
+		ValidArgsFunction: cyargs.CompletePluginVersionID,
 		Short:             "List versions of a plugin",
 		Example: `
-  cy plugin registry plugin version list my-registry my-plugin
+  cy plugin registry plugin version list --registry my-registry --plugin my-plugin
 `,
 		RunE: listVersions,
 	}
+	_ = cmd.MarkFlagRequired(cyargs.AddRegistryFlag(cmd))
+	_ = cmd.MarkFlagRequired(cyargs.AddPluginFlag(cmd))
+	return cmd
 }
 
 func listVersions(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
 
-	registryID, pluginID, err := resolveRegistryAndPlugin(org, args, m)
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	registryID, pluginID, err := resolveRegistryAndPlugin(org, cmd, m)
 	if err != nil {
 		return err
 	}

--- a/cmd/cycloid/plugins/registry/plugin/version/list.go
+++ b/cmd/cycloid/plugins/registry/plugin/version/list.go
@@ -1,0 +1,42 @@
+package version
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:               "list <registry> <plugin>",
+		Args:              cobra.ExactArgs(2),
+		ValidArgsFunction: cyargs.CompleteRegistryPluginID,
+		Short:             "List versions of a plugin",
+		Example: `
+  cy plugin registry plugin version list my-registry my-plugin
+`,
+		RunE: listVersions,
+	}
+}
+
+func listVersions(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	registryID, pluginID, err := resolveRegistryAndPlugin(org, args, m)
+	if err != nil {
+		return err
+	}
+
+	result, _, err := m.ListPluginVersions(org, registryID, pluginID)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to list plugin versions", printer.Options{})
+}

--- a/cmd/cycloid/plugins/registry/plugin/version/logs.go
+++ b/cmd/cycloid/plugins/registry/plugin/version/logs.go
@@ -11,33 +11,36 @@ import (
 )
 
 func NewLogsCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:               "logs <registry> <plugin> <version-id>",
-		Args:              cobra.ExactArgs(3),
-		ValidArgsFunction: cyargs.CompleteRegistryPluginID,
+	cmd := &cobra.Command{
+		Use:               "logs <version-id>",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cyargs.CompletePluginVersionID,
 		Short:             "Show installation logs for a plugin version",
 		Example: `
-  cy plugin registry plugin version logs my-registry my-plugin 7
+  cy plugin registry plugin version logs 7 --registry my-registry --plugin my-plugin
 `,
 		RunE: versionLogs,
 	}
+	_ = cmd.MarkFlagRequired(cyargs.AddRegistryFlag(cmd))
+	_ = cmd.MarkFlagRequired(cyargs.AddPluginFlag(cmd))
+	return cmd
 }
 
 func versionLogs(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
 
-	registryID, pluginID, err := resolveRegistryAndPlugin(org, args, m)
+	versionID, err := parseVersionID(args[0])
 	if err != nil {
 		return err
 	}
 
-	versionID, err := parseVersionID(args[2])
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	registryID, pluginID, err := resolveRegistryAndPlugin(org, cmd, m)
 	if err != nil {
 		return err
 	}

--- a/cmd/cycloid/plugins/registry/plugin/version/logs.go
+++ b/cmd/cycloid/plugins/registry/plugin/version/logs.go
@@ -1,0 +1,47 @@
+package version
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewLogsCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:               "logs <registry> <plugin> <version-id>",
+		Args:              cobra.ExactArgs(3),
+		ValidArgsFunction: cyargs.CompleteRegistryPluginID,
+		Short:             "Show installation logs for a plugin version",
+		Example: `
+  cy plugin registry plugin version logs my-registry my-plugin 7
+`,
+		RunE: versionLogs,
+	}
+}
+
+func versionLogs(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	registryID, pluginID, err := resolveRegistryAndPlugin(org, args, m)
+	if err != nil {
+		return err
+	}
+
+	versionID, err := parseVersionID(args[2])
+	if err != nil {
+		return err
+	}
+
+	result, _, err := m.ListPluginVersionLogs(org, registryID, pluginID, versionID)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to get plugin version logs", printer.Options{})
+}

--- a/cmd/cycloid/plugins/registry/plugin/version/publish.go
+++ b/cmd/cycloid/plugins/registry/plugin/version/publish.go
@@ -1,0 +1,73 @@
+package version
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewPublishCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "publish <registry> <plugin>",
+		Args:              cobra.ExactArgs(2),
+		ValidArgsFunction: cyargs.CompleteRegistryPluginID,
+		Short:             "Publish a new version of a plugin",
+		Example: `
+  # Publish an archive-based plugin version
+  cy plugin registry plugin version publish my-registry my-plugin --url https://example.com/plugin-v1.2.tar.gz
+
+  # Publish a Docker image-based plugin version
+  cy plugin registry plugin version publish my-registry my-plugin --docker-image docker-registry:5000/org/plugin:42
+`,
+		RunE: publishVersion,
+	}
+
+	cyargs.AddURLFlag(cmd, "URL of the plugin version archive (mutually exclusive with --docker-image)")
+	cyargs.AddDockerImageFlag(cmd)
+	return cmd
+}
+
+func publishVersion(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	registryID, pluginID, err := resolveRegistryAndPlugin(org, args, m)
+	if err != nil {
+		return err
+	}
+
+	url, err := cyargs.GetURL(cmd)
+	if err != nil {
+		return errors.Wrap(err, "unable to get --url flag")
+	}
+
+	dockerImage, err := cyargs.GetDockerImage(cmd)
+	if err != nil {
+		return errors.Wrap(err, "unable to get --docker-image flag")
+	}
+
+	if url == "" && dockerImage == "" {
+		return errors.New("one of --url or --docker-image is required")
+	}
+	if url != "" && dockerImage != "" {
+		return errors.New("--url and --docker-image are mutually exclusive")
+	}
+
+	versionURL := url
+	if dockerImage != "" {
+		versionURL = dockerImage
+	}
+
+	result, _, err := m.CreatePluginVersion(org, registryID, pluginID, versionURL)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to publish plugin version", printer.Options{})
+}

--- a/cmd/cycloid/plugins/registry/plugin/version/publish.go
+++ b/cmd/cycloid/plugins/registry/plugin/version/publish.go
@@ -13,35 +13,29 @@ import (
 
 func NewPublishCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "publish <registry> <plugin>",
-		Args:              cobra.ExactArgs(2),
-		ValidArgsFunction: cyargs.CompleteRegistryPluginID,
+		Use:               "publish",
+		Args:              cobra.NoArgs,
+		ValidArgsFunction: cyargs.CompletePluginVersionID,
 		Short:             "Publish a new version of a plugin",
 		Example: `
   # Publish an archive-based plugin version
-  cy plugin registry plugin version publish my-registry my-plugin --url https://example.com/plugin-v1.2.tar.gz
+  cy plugin registry plugin version publish --registry my-registry --plugin my-plugin --url https://example.com/plugin-v1.2.tar.gz
 
   # Publish a Docker image-based plugin version
-  cy plugin registry plugin version publish my-registry my-plugin --docker-image docker-registry:5000/org/plugin:42
+  cy plugin registry plugin version publish --registry my-registry --plugin my-plugin --docker-image docker-registry:5000/org/plugin:42
 `,
 		RunE: publishVersion,
 	}
 
+	_ = cmd.MarkFlagRequired(cyargs.AddRegistryFlag(cmd))
+	_ = cmd.MarkFlagRequired(cyargs.AddPluginFlag(cmd))
 	cyargs.AddURLFlag(cmd, "URL of the plugin version archive (mutually exclusive with --docker-image)")
 	cyargs.AddDockerImageFlag(cmd)
 	return cmd
 }
 
 func publishVersion(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
-	if err != nil {
-		return err
-	}
-
-	registryID, pluginID, err := resolveRegistryAndPlugin(org, args, m)
 	if err != nil {
 		return err
 	}
@@ -66,6 +60,14 @@ func publishVersion(cmd *cobra.Command, args []string) error {
 	versionURL := url
 	if dockerImage != "" {
 		versionURL = dockerImage
+	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	registryID, pluginID, err := resolveRegistryAndPlugin(org, cmd, m)
+	if err != nil {
+		return err
 	}
 
 	result, _, err := m.CreatePluginVersion(org, registryID, pluginID, versionURL)

--- a/cmd/cycloid/plugins/registry/plugin/version/retry.go
+++ b/cmd/cycloid/plugins/registry/plugin/version/retry.go
@@ -1,0 +1,47 @@
+package version
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewRetryCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:               "retry <registry> <plugin> <version-id>",
+		Args:              cobra.ExactArgs(3),
+		ValidArgsFunction: cyargs.CompleteRegistryPluginID,
+		Short:             "Retry a failed plugin version installation",
+		Example: `
+  cy plugin registry plugin version retry my-registry my-plugin 7
+`,
+		RunE: retryVersion,
+	}
+}
+
+func retryVersion(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	registryID, pluginID, err := resolveRegistryAndPlugin(org, args, m)
+	if err != nil {
+		return err
+	}
+
+	versionID, err := parseVersionID(args[2])
+	if err != nil {
+		return err
+	}
+
+	_, err = m.RetryPluginVersion(org, registryID, pluginID, versionID)
+	return cyout.PrintWithOptions(cmd, nil, err, "unable to retry plugin version install", printer.Options{})
+}

--- a/cmd/cycloid/plugins/registry/plugin/version/retry.go
+++ b/cmd/cycloid/plugins/registry/plugin/version/retry.go
@@ -11,33 +11,36 @@ import (
 )
 
 func NewRetryCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:               "retry <registry> <plugin> <version-id>",
-		Args:              cobra.ExactArgs(3),
-		ValidArgsFunction: cyargs.CompleteRegistryPluginID,
+	cmd := &cobra.Command{
+		Use:               "retry <version-id>",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cyargs.CompletePluginVersionID,
 		Short:             "Retry a failed plugin version installation",
 		Example: `
-  cy plugin registry plugin version retry my-registry my-plugin 7
+  cy plugin registry plugin version retry 7 --registry my-registry --plugin my-plugin
 `,
 		RunE: retryVersion,
 	}
+	_ = cmd.MarkFlagRequired(cyargs.AddRegistryFlag(cmd))
+	_ = cmd.MarkFlagRequired(cyargs.AddPluginFlag(cmd))
+	return cmd
 }
 
 func retryVersion(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
 
-	registryID, pluginID, err := resolveRegistryAndPlugin(org, args, m)
+	versionID, err := parseVersionID(args[0])
 	if err != nil {
 		return err
 	}
 
-	versionID, err := parseVersionID(args[2])
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	registryID, pluginID, err := resolveRegistryAndPlugin(org, cmd, m)
 	if err != nil {
 		return err
 	}

--- a/cmd/cycloid/plugins/registry/update.go
+++ b/cmd/cycloid/plugins/registry/update.go
@@ -23,25 +23,25 @@ func NewUpdateCommand() *cobra.Command {
 		RunE: updatePluginRegistry,
 	}
 
-	cmd.MarkFlagRequired(cyargs.AddNameFlag(cmd))
+	_ = cmd.MarkFlagRequired(cyargs.AddNameFlag(cmd))
 	return cmd
 }
 
 func updatePluginRegistry(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
 
-	id, err := cyargs.ResolvePluginRegistryID(org, args[0], m)
+	name, err := cyargs.GetName(cmd)
 	if err != nil {
 		return err
 	}
 
-	name, err := cyargs.GetName(cmd)
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	id, err := cyargs.ResolvePluginRegistryID(org, args[0], m)
 	if err != nil {
 		return err
 	}

--- a/cmd/cycloid/plugins/registry/update.go
+++ b/cmd/cycloid/plugins/registry/update.go
@@ -1,0 +1,51 @@
+package registry
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewUpdateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "update <id-or-name-or-url>",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cyargs.CompletePluginRegistryID,
+		Short:             "Update a plugin registry",
+		Example: `
+  cy plugin registry update 1 --name new-name
+  cy plugin registry update my-registry --name renamed
+`,
+		RunE: updatePluginRegistry,
+	}
+
+	cmd.MarkFlagRequired(cyargs.AddNameFlag(cmd))
+	return cmd
+}
+
+func updatePluginRegistry(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	id, err := cyargs.ResolvePluginRegistryID(org, args[0], m)
+	if err != nil {
+		return err
+	}
+
+	name, err := cyargs.GetName(cmd)
+	if err != nil {
+		return err
+	}
+
+	result, _, err := m.UpdatePluginRegistry(org, id, name)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to update plugin registry", printer.Options{})
+}

--- a/cmd/cycloid/plugins/uninstall.go
+++ b/cmd/cycloid/plugins/uninstall.go
@@ -26,13 +26,13 @@ func NewUninstallCommand() *cobra.Command {
 }
 
 func uninstallPlugin(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
 
 	for _, arg := range args {
 		id, err := cyargs.ResolvePluginInstallID(org, arg, m)

--- a/cmd/cycloid/plugins/uninstall.go
+++ b/cmd/cycloid/plugins/uninstall.go
@@ -1,0 +1,49 @@
+package plugins
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewUninstallCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:               "uninstall <id-or-name>...",
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: cyargs.CompletePluginInstallID,
+		Short:             "Uninstall a plugin",
+		Example: `
+  cy plugin uninstall 42
+  cy plugin uninstall my-plugin
+  cy plugin uninstall my-plugin-a my-plugin-b
+`,
+		RunE: uninstallPlugin,
+	}
+}
+
+func uninstallPlugin(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	for _, arg := range args {
+		id, err := cyargs.ResolvePluginInstallID(org, arg, m)
+		if err != nil {
+			return err
+		}
+
+		_, err = m.DeletePlugin(org, id)
+		if err != nil {
+			return cyout.PrintWithOptions(cmd, nil, err, "unable to uninstall plugin "+arg, printer.Options{})
+		}
+	}
+	return cyout.PrintWithOptions(cmd, nil, nil, "", printer.Options{})
+}

--- a/cmd/cycloid/plugins/upgrade.go
+++ b/cmd/cycloid/plugins/upgrade.go
@@ -1,0 +1,60 @@
+package plugins
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewUpgradeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "upgrade <id-or-name>",
+		Aliases:           []string{"update"},
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cyargs.CompletePluginInstallID,
+		Short:             "Upgrade a plugin to a new version",
+		Example: `
+  cy plugin upgrade 42 --version-id 7 --config host=localhost
+  cy plugin upgrade my-plugin --version-id 7 --config-file ./config.json
+`,
+		RunE: upgradePlugin,
+	}
+
+	cyargs.AddPluginVersionIDFlag(cmd)
+	cmd.MarkFlagRequired("version-id")
+	cyargs.AddPluginConfigFlags(cmd)
+	return cmd
+}
+
+func upgradePlugin(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	id, err := cyargs.ResolvePluginInstallID(org, args[0], m)
+	if err != nil {
+		return err
+	}
+
+	versionID, err := cmd.Flags().GetUint32("version-id")
+	if err != nil {
+		return errors.Wrap(err, "unable to get --version-id flag")
+	}
+
+	config, err := cyargs.GetPluginConfig(cmd)
+	if err != nil {
+		return errors.Wrap(err, "unable to get plugin configuration")
+	}
+
+	result, _, err := m.UpdatePlugin(org, id, versionID, config)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to upgrade plugin", printer.Options{})
+}

--- a/cmd/cycloid/plugins/upgrade.go
+++ b/cmd/cycloid/plugins/upgrade.go
@@ -26,26 +26,18 @@ func NewUpgradeCommand() *cobra.Command {
 	}
 
 	cyargs.AddPluginVersionIDFlag(cmd)
-	cmd.MarkFlagRequired("version-id")
+	_ = cmd.MarkFlagRequired("version-id")
 	cyargs.AddPluginConfigFlags(cmd)
 	return cmd
 }
 
 func upgradePlugin(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
 
-	id, err := cyargs.ResolvePluginInstallID(org, args[0], m)
-	if err != nil {
-		return err
-	}
-
-	versionID, err := cmd.Flags().GetUint32("version-id")
+	versionID, err := cyargs.GetPluginVersionID(cmd)
 	if err != nil {
 		return errors.Wrap(err, "unable to get --version-id flag")
 	}
@@ -55,6 +47,14 @@ func upgradePlugin(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "unable to get plugin configuration")
 	}
 
-	result, _, err := m.UpdatePlugin(org, id, versionID, config)
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	id, err := cyargs.ResolvePluginInstallID(org, args[0], m)
+	if err != nil {
+		return err
+	}
+
+	result, _, err := m.UpdatePlugin(org, id, *versionID, config)
 	return cyout.PrintWithOptions(cmd, result, err, "unable to upgrade plugin", printer.Options{})
 }

--- a/cmd/cycloid/plugins/widget/cmd.go
+++ b/cmd/cycloid/plugins/widget/cmd.go
@@ -1,0 +1,19 @@
+package widget
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewCommands() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "widget",
+		Aliases: []string{"widgets"},
+		Short:   "Manage org-level plugin widgets",
+	}
+
+	cmd.AddCommand(
+		NewListCommand(),
+		NewQueryCommand(),
+	)
+	return cmd
+}

--- a/cmd/cycloid/plugins/widget/list.go
+++ b/cmd/cycloid/plugins/widget/list.go
@@ -26,9 +26,6 @@ func NewListCommand() *cobra.Command {
 }
 
 func listPluginWidgets(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
@@ -38,6 +35,9 @@ func listPluginWidgets(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
 
 	result, _, err := m.ListPluginWidgets(org, placement)
 	return cyout.PrintWithOptions(cmd, result, err, "unable to list plugin widgets", printer.Options{})

--- a/cmd/cycloid/plugins/widget/list.go
+++ b/cmd/cycloid/plugins/widget/list.go
@@ -1,0 +1,44 @@
+package widget
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Args:  cobra.NoArgs,
+		Short: "List org-level plugin widgets",
+		Example: `
+  cy plugin widget list --placement sideMenuPage
+  cy plugin widget list --placement component
+`,
+		RunE: listPluginWidgets,
+	}
+	cmd.Flags().String("placement", "sideMenuPage", "filter widgets by placement type (e.g. sideMenuPage, component)")
+	return cmd
+}
+
+func listPluginWidgets(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	placement, err := cmd.Flags().GetString("placement")
+	if err != nil {
+		return err
+	}
+
+	result, _, err := m.ListPluginWidgets(org, placement)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to list plugin widgets", printer.Options{})
+}

--- a/cmd/cycloid/plugins/widget/query.go
+++ b/cmd/cycloid/plugins/widget/query.go
@@ -43,13 +43,13 @@ Use 'cy plugin widget list' to discover widget IDs and their configured queries.
 }
 
 func queryPluginWidget(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
+
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
 
 	n, err := strconv.ParseUint(args[0], 10, 32)
 	if err != nil {

--- a/cmd/cycloid/plugins/widget/query.go
+++ b/cmd/cycloid/plugins/widget/query.go
@@ -1,0 +1,62 @@
+package widget
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/internal/cyargs"
+	"github.com/cycloidio/cycloid-cli/internal/cyout"
+	"github.com/cycloidio/cycloid-cli/printer"
+)
+
+func NewQueryCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "query <widget-id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Execute the data query configured for a plugin widget",
+		Long: `Execute the data query pre-configured for a plugin widget and return its results.
+
+Each plugin widget is an instance of a query defined in the plugin manifest.
+A single plugin may expose multiple queries; each becomes a separate widget with
+its own ID. This command executes the query bound to the given widget and returns
+whatever data the plugin produces — the shape is plugin-defined.
+
+Only widgets of type "table" are supported. The associated plugin must be running.
+
+Use 'cy plugin widget list' to discover widget IDs and their configured queries.`,
+		Example: `
+  # List available widgets to find the ID you want
+  cy plugin widget list
+
+  # Execute the query for widget 42 and print results as a table
+  cy plugin widget query 42
+
+  # Get the raw JSON output
+  cy plugin widget query 42 --output json
+`,
+		RunE: queryPluginWidget,
+	}
+}
+
+func queryPluginWidget(cmd *cobra.Command, args []string) error {
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	n, err := strconv.ParseUint(args[0], 10, 32)
+	if err != nil {
+		return fmt.Errorf("invalid widget-id %q: must be a positive integer", args[0])
+	}
+	widgetID := uint32(n)
+
+	result, _, err := m.QueryPluginWidget(org, widgetID)
+	return cyout.PrintWithOptions(cmd, result, err, "unable to query plugin widget", printer.Options{})
+}

--- a/cmd/cycloid/projects/delete.go
+++ b/cmd/cycloid/projects/delete.go
@@ -43,7 +43,7 @@ func deleteProject(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if projectFlag, err := cyargs.GetProject(cmd); err != nil {
+	if projectFlag, err := cyargs.GetProjectOrEmpty(cmd); err != nil {
 		return err
 	} else if projectFlag != "" {
 		found := false

--- a/cmd/cycloid/projects/get.go
+++ b/cmd/cycloid/projects/get.go
@@ -43,7 +43,7 @@ func get(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if projectFlag, err := cyargs.GetProject(cmd); err != nil {
+	if projectFlag, err := cyargs.GetProjectOrEmpty(cmd); err != nil {
 		return err
 	} else if projectFlag != "" {
 		found := false

--- a/compose.yml
+++ b/compose.yml
@@ -266,6 +266,8 @@ services:
   ## Plugin manager service
   plugin-manager:
     image: cycloid/plugin-manager:latest
+    ports:
+      - "${PLUGIN_MANAGER_HOST_PORT:-4000}:4000"
     environment:
       LOG_LEVEL: debug
       PORT: "4000"

--- a/e2e/plugin_setup_test.go
+++ b/e2e/plugin_setup_test.go
@@ -1,0 +1,66 @@
+package e2e_test
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sync"
+	"testing"
+)
+
+const (
+	helloWorldSource = "cycloid/plugin-hello-world:latest"
+	// baseLocalImage is the base path in the host-reachable registry.
+	baseLocalImage = "localhost:5000/plugin-hello-world"
+	// baseAPIImage is the base path as seen from inside the docker network.
+	// Must match the registry URL configured in the plugin-registry service.
+	baseAPIImage = "docker-registry:5000/plugin-hello-world"
+)
+
+var imageOnce sync.Once
+
+// ensureHelloWorldImage ensures the plugin-hello-world source image is pulled once.
+// Unique tags are pushed on demand by uniqueHelloWorldVersion.
+func ensureHelloWorldImage(t *testing.T) {
+	t.Helper()
+	imageOnce.Do(func() {
+		run := func(name string, args ...string) {
+			cmd := exec.Command(name, args...)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				t.Fatalf("command %q %v failed: %v", name, args, err)
+			}
+		}
+		run("docker", "pull", helloWorldSource)
+		run("docker", "login", "localhost:5000", "-u", "cycloid", "-p", "cycloid123")
+	})
+}
+
+// uniqueHelloWorldVersion generates a unique semver-compatible image tag, pushes it
+// to the local registry, and returns the docker-registry:5000 URL for use with the API.
+// The plugin-registry enforces a global unique constraint on version URLs, so each
+// call to CreatePluginVersion must use a different image tag.
+func uniqueHelloWorldVersion(t *testing.T) string {
+	t.Helper()
+	ensureHelloWorldImage(t)
+
+	tag := fmt.Sprintf("1.0.%d", rand.Intn(999999))
+	local := fmt.Sprintf("%s:%s", baseLocalImage, tag)
+	api := fmt.Sprintf("%s:%s", baseAPIImage, tag)
+
+	run := func(name string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(name, args...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("uniqueHelloWorldVersion: %q %v failed: %v", name, args, err)
+		}
+	}
+
+	run("docker", "tag", helloWorldSource, local)
+	run("docker", "push", local)
+	return api
+}

--- a/e2e/plugins_test.go
+++ b/e2e/plugins_test.go
@@ -1,0 +1,586 @@
+package e2e_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pluginsEnabled reports whether the plugin e2e suite should run.
+func pluginsEnabled() bool {
+	return os.Getenv("CY_TEST_E2E_PLUGINS") == "1"
+}
+
+// pollPluginRunning polls GetPlugin until Status == "running" or timeout.
+// Returns true if "running" was reached, false on timeout (plugin-manager may lack
+// a container runtime in the compose test environment).
+func pollPluginRunning(t *testing.T, org string, installID uint32) bool {
+	t.Helper()
+	deadline := time.Now().Add(90 * time.Second)
+	for time.Now().Before(deadline) {
+		install, _, err := config.Middleware.GetPlugin(org, installID)
+		if err == nil && install != nil && install.Status != nil && *install.Status == "running" {
+			return true
+		}
+		if err == nil && install != nil && install.Status != nil && *install.Status == "failed" {
+			t.Logf("plugin install %d entered failed state (plugin-manager may lack container runtime)", installID)
+			return false
+		}
+		time.Sleep(3 * time.Second)
+	}
+	t.Logf("plugin install %d did not reach running state within 90s (plugin-manager may lack container runtime)", installID)
+	return false
+}
+
+func TestPluginManagers(t *testing.T) {
+	if !pluginsEnabled() {
+		t.Skip("set CY_TEST_E2E_PLUGINS=1 to run plugin e2e tests")
+	}
+
+	org := config.Org
+
+	t.Run("List", func(t *testing.T) {
+		out, err := executeCommand([]string{"plugin", "manager", "list", "--output", "json"})
+		require.NoError(t, err, "plugin manager list failed: %s", out)
+		var managers []map[string]any
+		require.NoError(t, json.Unmarshal([]byte(out), &managers), "output not valid JSON")
+	})
+
+	t.Run("AcceptTestPluginManager", func(t *testing.T) {
+		mgr, err := config.AcceptPluginManager(t)
+		require.NoError(t, err, "failed to accept test-plugin-manager")
+		require.NotNil(t, mgr)
+		// API returns "invite_accepted" once accepted.
+		assert.Contains(t, []string{"accepted", "invite_accepted"}, *mgr.InviteStatus)
+	})
+
+	t.Run("GetAfterAccept", func(t *testing.T) {
+		managers, _, err := config.Middleware.ListPluginManagers(org)
+		require.NoError(t, err)
+		var found bool
+		for _, m := range managers {
+			if m.Name != nil && *m.Name == "test-plugin-manager" {
+				found = true
+				assert.Contains(t, []string{"accepted", "invite_accepted"}, *m.InviteStatus)
+				break
+			}
+		}
+		assert.True(t, found, "test-plugin-manager not found after accept")
+	})
+}
+
+func TestPluginRegistries(t *testing.T) {
+	if !pluginsEnabled() {
+		t.Skip("set CY_TEST_E2E_PLUGINS=1 to run plugin e2e tests")
+	}
+
+	name := randomCanonical("e2e-registry")
+	// Use a unique offline URL per test run to avoid the API's one-URL-per-registry constraint.
+	regURL := fmt.Sprintf("http://test-reg-%s:9999", name)
+
+	t.Run("Create", func(t *testing.T) {
+		out, err := executeCommand([]string{
+			"plugin", "registry", "create",
+			"--name", name,
+			"--url", regURL,
+			"--output", "json",
+		})
+		require.NoError(t, err, "create failed: %s", out)
+		var reg map[string]any
+		require.NoError(t, json.Unmarshal([]byte(out), &reg))
+		assert.Equal(t, name, reg["name"])
+	})
+
+	defer t.Run("Cleanup", func(t *testing.T) {
+		_, err := executeCommand([]string{"plugin", "registry", "delete", name})
+		assert.NoError(t, err, "cleanup delete failed")
+	})
+
+	t.Run("List", func(t *testing.T) {
+		out, err := executeCommand([]string{"plugin", "registry", "list", "--output", "json"})
+		require.NoError(t, err)
+		names, err := JSONListExtractFields(out, "name", "", "")
+		require.NoError(t, err)
+		assert.Contains(t, names, name)
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		out, err := executeCommand([]string{"plugin", "registry", "get", name, "--output", "json"})
+		require.NoError(t, err, "get failed: %s", out)
+		var reg map[string]any
+		require.NoError(t, json.Unmarshal([]byte(out), &reg))
+		assert.Equal(t, name, reg["name"])
+	})
+
+	t.Run("UpdateName", func(t *testing.T) {
+		renamed := name + "-r"
+		out, err := executeCommand([]string{
+			"plugin", "registry", "update", name,
+			"--name", renamed,
+			"--output", "json",
+		})
+		require.NoError(t, err, "update failed: %s", out)
+		var reg map[string]any
+		require.NoError(t, json.Unmarshal([]byte(out), &reg))
+		assert.Equal(t, renamed, reg["name"])
+		// Rename back so subsequent subtests can find by original name.
+		_, err = executeCommand([]string{
+			"plugin", "registry", "update", renamed,
+			"--name", name,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("CreateIdempotentWithUpdate", func(t *testing.T) {
+		out, err := executeCommand([]string{
+			"plugin", "registry", "create",
+			"--name", name,
+			"--url", regURL,
+			"--update",
+			"--output", "json",
+		})
+		require.NoError(t, err, "create --update failed: %s", out)
+		var reg map[string]any
+		require.NoError(t, json.Unmarshal([]byte(out), &reg))
+		assert.Equal(t, name, reg["name"])
+	})
+
+	t.Run("CreateDuplicateFails", func(t *testing.T) {
+		_, err := executeCommand([]string{
+			"plugin", "registry", "create",
+			"--name", name,
+			"--url", regURL,
+		})
+		assert.Error(t, err, "expected error creating duplicate registry without --update")
+	})
+}
+
+func TestRegistryPlugins(t *testing.T) {
+	if !pluginsEnabled() {
+		t.Skip("set CY_TEST_E2E_PLUGINS=1 to run plugin e2e tests")
+	}
+
+	regURL := "http://plugin-registry:4000"
+	reg, err := config.NewTestPluginRegistry(t, randomCanonical("e2e-reg-pl"), regURL)
+	require.NoError(t, err)
+	regID := *reg.ID
+	regName := *reg.Name
+
+	pluginName := randomCanonical("e2e-plugin")
+
+	t.Run("Create", func(t *testing.T) {
+		out, err := executeCommand([]string{
+			"plugin", "registry", "plugin", "create",
+			regName,
+			"--name", pluginName,
+			"--output", "json",
+		})
+		require.NoError(t, err, "create plugin failed: %s", out)
+		var p map[string]any
+		require.NoError(t, json.Unmarshal([]byte(out), &p))
+		assert.Equal(t, pluginName, p["name"])
+	})
+
+	defer t.Run("CleanupPlugin", func(t *testing.T) {
+		_, _ = executeCommand([]string{
+			"plugin", "registry", "plugin", "delete",
+			regName,
+			pluginName,
+		})
+	})
+
+	t.Run("List", func(t *testing.T) {
+		out, err := executeCommand([]string{
+			"plugin", "registry", "plugin", "list",
+			regName,
+			"--output", "json",
+		})
+		require.NoError(t, err)
+		names, err := JSONListExtractFields(out, "name", "", "")
+		require.NoError(t, err)
+		assert.Contains(t, names, pluginName)
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		out, err := executeCommand([]string{
+			"plugin", "registry", "plugin", "get",
+			pluginName,
+			"--registry", regName,
+			"--output", "json",
+		})
+		require.NoError(t, err, "get plugin failed: %s", out)
+		var p map[string]any
+		require.NoError(t, json.Unmarshal([]byte(out), &p))
+		assert.Equal(t, pluginName, p["name"])
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		renamed := pluginName + "-r"
+		out, err := executeCommand([]string{
+			"plugin", "registry", "plugin", "update",
+			regName,
+			pluginName,
+			"--name", renamed,
+			"--output", "json",
+		})
+		require.NoError(t, err, "update plugin failed: %s", out)
+		var p map[string]any
+		require.NoError(t, json.Unmarshal([]byte(out), &p))
+		assert.Equal(t, renamed, p["name"])
+		// Rename back.
+		_, err = executeCommand([]string{
+			"plugin", "registry", "plugin", "update",
+			regName,
+			renamed,
+			"--name", pluginName,
+		})
+		require.NoError(t, err)
+	})
+
+	_ = regID
+}
+
+func TestPluginVersions(t *testing.T) {
+	if !pluginsEnabled() {
+		t.Skip("set CY_TEST_E2E_PLUGINS=1 to run plugin e2e tests")
+	}
+
+	ensureHelloWorldImage(t)
+
+	regURL := "http://plugin-registry:4000"
+	reg, err := config.NewTestPluginRegistry(t, randomCanonical("e2e-reg-ver"), regURL)
+	require.NoError(t, err)
+	regName := *reg.Name
+
+	plugin, err := config.NewTestPluginInRegistry(t, *reg.ID, randomCanonical("e2e-plver"))
+	require.NoError(t, err)
+	pluginID := *plugin.ID
+	pluginName := *plugin.Name
+
+	t.Run("Publish", func(t *testing.T) {
+		out, err := executeCommand([]string{
+			"plugin", "registry", "plugin", "version", "publish",
+			"--registry", regName,
+			"--plugin", pluginName,
+			"--docker-image", uniqueHelloWorldVersion(t),
+			"--output", "json",
+		})
+		require.NoError(t, err, "publish failed: %s", out)
+		var v map[string]any
+		require.NoError(t, json.Unmarshal([]byte(out), &v))
+		assert.NotEmpty(t, v["id"])
+	})
+
+	versions, _, err := config.Middleware.ListPluginVersions(config.Org, *reg.ID, pluginID)
+	require.NoError(t, err)
+	require.NotEmpty(t, versions, "no versions after publish")
+	versionID := *versions[0].ID
+
+	t.Run("List", func(t *testing.T) {
+		out, err := executeCommand([]string{
+			"plugin", "registry", "plugin", "version", "list",
+			"--registry", regName,
+			"--plugin", pluginName,
+			"--output", "json",
+		})
+		require.NoError(t, err)
+		var vs []map[string]any
+		require.NoError(t, json.Unmarshal([]byte(out), &vs))
+		assert.NotEmpty(t, vs)
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		out, err := executeCommand([]string{
+			"plugin", "registry", "plugin", "version", "get",
+			fmt.Sprint(versionID),
+			"--registry", regName,
+			"--plugin", pluginName,
+			"--output", "json",
+		})
+		require.NoError(t, err, "get version failed: %s", out)
+		var v map[string]any
+		require.NoError(t, json.Unmarshal([]byte(out), &v))
+		assert.NotEmpty(t, v["id"])
+	})
+
+	t.Run("Logs", func(t *testing.T) {
+		// Version logs endpoint should succeed even when empty.
+		out, err := executeCommand([]string{
+			"plugin", "registry", "plugin", "version", "logs",
+			fmt.Sprint(versionID),
+			"--registry", regName,
+			"--plugin", pluginName,
+			"--output", "json",
+		})
+		require.NoError(t, err, "version logs failed: %s", out)
+	})
+
+	defer t.Run("Delete", func(t *testing.T) {
+		_, err := executeCommand([]string{
+			"plugin", "registry", "plugin", "version", "delete",
+			fmt.Sprint(versionID),
+			"--registry", regName,
+			"--plugin", pluginName,
+		})
+		assert.NoError(t, err)
+	})
+}
+
+func TestPluginInstallLifecycle(t *testing.T) {
+	if !pluginsEnabled() {
+		t.Skip("set CY_TEST_E2E_PLUGINS=1 to run plugin e2e tests")
+	}
+
+	ensureHelloWorldImage(t)
+
+	org := config.Org
+
+	// Ensure test-plugin-manager is accepted.
+	_, err := config.AcceptPluginManager(t)
+	require.NoError(t, err, "failed to accept test-plugin-manager")
+
+	regURL := "http://plugin-registry:4000"
+	reg, err := config.NewTestPluginRegistry(t, randomCanonical("e2e-reg-inst"), regURL)
+	require.NoError(t, err)
+	regName := *reg.Name
+
+	plugin, err := config.NewTestPluginInRegistry(t, *reg.ID, randomCanonical("e2e-plinst"))
+	require.NoError(t, err)
+	pluginName := *plugin.Name
+
+	version, err := config.NewTestPluginVersion(t, *reg.ID, *plugin.ID, uniqueHelloWorldVersion(t))
+	require.NoError(t, err)
+	versionID := *version.ID
+
+	var installID uint32
+
+	t.Run("Install", func(t *testing.T) {
+		_, err := executeCommand([]string{
+			"plugin", "registry", "plugin", "version", "install",
+			fmt.Sprint(versionID),
+			"--registry", regName,
+			"--plugin", pluginName,
+		})
+		require.NoError(t, err, "install failed")
+
+		// Resolve the install ID from the plugin list.
+		installs, _, err := config.Middleware.ListPlugins(org)
+		require.NoError(t, err)
+		for _, p := range installs {
+			if p.Name != nil && *p.Name == pluginName && p.Install != nil {
+				installID = *p.Install.ID
+				break
+			}
+		}
+		require.NotZero(t, installID, "install record not found after install")
+	})
+
+	var pluginRunning bool
+	t.Run("PollRunning", func(t *testing.T) {
+		if installID == 0 {
+			t.Skip("install step did not complete")
+		}
+		pluginRunning = pollPluginRunning(t, org, installID)
+		if !pluginRunning {
+			t.Skip("plugin did not reach running state (plugin-manager may lack container runtime)")
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		if installID == 0 {
+			t.Skip("install step did not complete")
+		}
+		out, err := executeCommand([]string{
+			"plugin", "get", fmt.Sprint(installID),
+			"--output", "json",
+		})
+		require.NoError(t, err, "plugin get failed: %s", out)
+		var install map[string]any
+		require.NoError(t, json.Unmarshal([]byte(out), &install))
+		assert.NotNil(t, install["id"], "install record should have an id")
+	})
+
+	t.Run("List", func(t *testing.T) {
+		out, err := executeCommand([]string{"plugin", "list", "--output", "json"})
+		require.NoError(t, err)
+		var installs []map[string]any
+		require.NoError(t, json.Unmarshal([]byte(out), &installs))
+		assert.NotEmpty(t, installs)
+	})
+
+	t.Run("RetryIdempotent", func(t *testing.T) {
+		// A second install with --retry should not fail with 409.
+		_, err := executeCommand([]string{
+			"plugin", "registry", "plugin", "version", "install",
+			fmt.Sprint(versionID),
+			"--registry", regName,
+			"--plugin", pluginName,
+			"--retry",
+		})
+		require.NoError(t, err, "install --retry on already-installed version should succeed")
+	})
+
+	defer t.Run("Uninstall", func(t *testing.T) {
+		if installID == 0 {
+			return
+		}
+		_, err := executeCommand([]string{"plugin", "uninstall", fmt.Sprint(installID)})
+		assert.NoError(t, err, "uninstall failed")
+	})
+}
+
+func TestPluginWidgets(t *testing.T) {
+	if !pluginsEnabled() {
+		t.Skip("set CY_TEST_E2E_PLUGINS=1 to run plugin e2e tests")
+	}
+
+	ensureHelloWorldImage(t)
+
+	org := config.Org
+
+	// Ensure test-plugin-manager is accepted.
+	_, err := config.AcceptPluginManager(t)
+	require.NoError(t, err, "failed to accept test-plugin-manager")
+
+	regURL := "http://plugin-registry:4000"
+	reg, err := config.NewTestPluginRegistry(t, randomCanonical("e2e-reg-wgt"), regURL)
+	require.NoError(t, err)
+	regName := *reg.Name
+
+	plugin, err := config.NewTestPluginInRegistry(t, *reg.ID, randomCanonical("e2e-plwgt"))
+	require.NoError(t, err)
+	pluginName := *plugin.Name
+
+	version, err := config.NewTestPluginVersion(t, *reg.ID, *plugin.ID, uniqueHelloWorldVersion(t))
+	require.NoError(t, err)
+	versionID := *version.ID
+
+	// Install and wait for running.
+	_, err = executeCommand([]string{
+		"plugin", "registry", "plugin", "version", "install",
+		fmt.Sprint(versionID),
+		"--registry", regName,
+		"--plugin", pluginName,
+	})
+	require.NoError(t, err)
+
+	installs, _, err := config.Middleware.ListPlugins(org)
+	require.NoError(t, err)
+	var installID uint32
+	for _, p := range installs {
+		if p.Name != nil && *p.Name == pluginName && p.Install != nil {
+			installID = *p.Install.ID
+			break
+		}
+	}
+	require.NotZero(t, installID)
+
+	defer t.Run("CleanupInstall", func(t *testing.T) {
+		_, _ = config.Middleware.DeletePlugin(org, installID)
+	})
+
+	running := pollPluginRunning(t, org, installID)
+
+	t.Run("ListWidgets", func(t *testing.T) {
+		if !running {
+			t.Skip("plugin not running — skipping widget test (plugin-manager may lack container runtime)")
+		}
+		out, err := executeCommand([]string{
+			"plugin", "widget", "list",
+			"--placement", "sideMenuPage",
+			"--output", "json",
+		})
+		require.NoError(t, err, "widget list failed: %s", out)
+		var widgets []map[string]any
+		require.NoError(t, json.Unmarshal([]byte(out), &widgets))
+		assert.NotEmpty(t, widgets, "expected at least one widget after install")
+	})
+
+	t.Run("IframeServedContent", func(t *testing.T) {
+		if !running {
+			t.Skip("plugin not running — skipping iframe test (plugin-manager may lack container runtime)")
+		}
+		// Resolve the widget URL from the plugin widget list and verify it
+		// serves HTML containing "Hello World".
+		widgets, _, err := config.Middleware.ListPluginWidgets(org, "sideMenuPage")
+		require.NoError(t, err)
+		require.NotEmpty(t, widgets, "no widgets found for sideMenuPage placement")
+
+		// Find the iframe widget belonging to our install.
+		var iframeURL string
+		for _, w := range widgets {
+			if w.Type == nil || *w.Type != "iframe" {
+				continue
+			}
+			// Widget field is a map with a "url" key.
+			wmap, ok := w.Widget.(map[string]any)
+			if !ok {
+				continue
+			}
+			rawURL, ok := wmap["url"].(string)
+			if !ok {
+				continue
+			}
+			iframeURL = rawURL
+			break
+		}
+		require.NotEmpty(t, iframeURL, "no iframe widget URL found")
+
+		// plugin-manager is reachable on localhost:4000 (compose port mapping).
+		hostURL := strings.ReplaceAll(iframeURL, "plugin-manager:4000", "localhost:4000")
+
+		resp, err := http.Get(hostURL) //nolint:noctx
+		require.NoError(t, err, "GET iframe URL failed: %s", hostURL)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Contains(t, strings.ToLower(string(body)), "hello world",
+			"iframe URL %s did not return Hello World content", hostURL)
+	})
+}
+
+func TestPluginCommandsErrorPaths(t *testing.T) {
+	if !pluginsEnabled() {
+		t.Skip("set CY_TEST_E2E_PLUGINS=1 to run plugin e2e tests")
+	}
+
+	t.Run("WatchIntervalTooShort", func(t *testing.T) {
+		_, err := executeCommand([]string{
+			"plugin", "logs", "999",
+			"--watch-interval", "100ms",
+		})
+		assert.Error(t, err, "expected error for --watch-interval below 500ms")
+		assert.Contains(t, err.Error(), "500ms")
+	})
+
+	t.Run("RegistryCreateMissingURL", func(t *testing.T) {
+		_, err := executeCommand([]string{
+			"plugin", "registry", "create",
+			"--name", "missing-url-test",
+		})
+		assert.Error(t, err, "expected error when --url is absent")
+	})
+
+	t.Run("InstallRetryOnNonExistent", func(t *testing.T) {
+		// Should fail cleanly, not panic.
+		_, err := executeCommand([]string{
+			"plugin", "registry", "plugin", "version", "install",
+			"--registry", "nonexistent-registry-e2e",
+			"--plugin", "nonexistent-plugin-e2e",
+			"99999",
+			"--retry",
+		})
+		assert.Error(t, err)
+	})
+}

--- a/internal/cyargs/plugins.go
+++ b/internal/cyargs/plugins.go
@@ -3,7 +3,6 @@ package cyargs
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -13,6 +12,38 @@ import (
 	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
 	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
 )
+
+// ---------------------------------------------------------------------------
+// Registry context flag (--registry, used by plugin and version subcommands)
+// ---------------------------------------------------------------------------
+
+// AddRegistryFlag registers a --registry flag and returns the flag name for use
+// with MarkFlagRequired.
+func AddRegistryFlag(cmd *cobra.Command) string {
+	cmd.Flags().String("registry", "", "plugin registry name, ID, or URL")
+	return "registry"
+}
+
+// GetRegistry reads the --registry flag value.
+func GetRegistry(cmd *cobra.Command) (string, error) {
+	return cmd.Flags().GetString("registry")
+}
+
+// ---------------------------------------------------------------------------
+// Plugin context flag (--plugin, used by version subcommands)
+// ---------------------------------------------------------------------------
+
+// AddPluginFlag registers a --plugin flag and returns the flag name for use
+// with MarkFlagRequired.
+func AddPluginFlag(cmd *cobra.Command) string {
+	cmd.Flags().String("plugin", "", "plugin name or ID within the registry")
+	return "plugin"
+}
+
+// GetPlugin reads the --plugin flag value.
+func GetPlugin(cmd *cobra.Command) (string, error) {
+	return cmd.Flags().GetString("plugin")
+}
 
 // ---------------------------------------------------------------------------
 // URL flag (registry add, manager create, version publish)
@@ -293,6 +324,79 @@ func ResolvePluginRegistryID(org, nameOrID string, m middleware.Middleware) (uin
 	return resolveUnique("plugin registry", nameOrID, matches)
 }
 
+// CompletePluginIDFromRegistryFlag completes plugin names/IDs by reading the registry
+// from the --registry flag rather than positional args.
+func CompletePluginIDFromRegistryFlag(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
+	registryStr, _ := cmd.Flags().GetString("registry")
+	if registryStr == "" {
+		return cobra.AppendActiveHelp(nil, "provide --registry first"), cobra.ShellCompDirectiveNoFileComp
+	}
+	org, err := GetOrg(cmd)
+	if err != nil {
+		return cobra.AppendActiveHelp(nil, "missing org: "+err.Error()), cobra.ShellCompDirectiveNoFileComp
+	}
+	m := middleware.NewMiddleware(common.NewAPI())
+	registryID, err := ResolvePluginRegistryID(org, registryStr, m)
+	if err != nil {
+		return cobra.AppendActiveHelp(nil, "failed to resolve registry: "+err.Error()), cobra.ShellCompDirectiveNoFileComp
+	}
+	plugins, _, err := m.ListRegistryPlugins(org, registryID)
+	if err != nil {
+		return cobra.AppendActiveHelp(nil, "failed to list plugins: "+err.Error()), cobra.ShellCompDirectiveNoFileComp
+	}
+	completions := make([]cobra.Completion, 0, len(plugins)*2)
+	for _, p := range plugins {
+		if p.ID == nil || p.Name == nil {
+			continue
+		}
+		idStr := strconv.Itoa(int(*p.ID))
+		completions = append(completions,
+			cobra.CompletionWithDesc(idStr, *p.Name),
+			cobra.CompletionWithDesc(*p.Name, "id:"+idStr),
+		)
+	}
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
+// CompletePluginVersionID completes version IDs by reading registry and plugin from flags.
+func CompletePluginVersionID(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
+	registryStr, _ := cmd.Flags().GetString("registry")
+	pluginStr, _ := cmd.Flags().GetString("plugin")
+	if registryStr == "" || pluginStr == "" {
+		return cobra.AppendActiveHelp(nil, "provide --registry and --plugin first"), cobra.ShellCompDirectiveNoFileComp
+	}
+	org, err := GetOrg(cmd)
+	if err != nil {
+		return cobra.AppendActiveHelp(nil, "missing org: "+err.Error()), cobra.ShellCompDirectiveNoFileComp
+	}
+	m := middleware.NewMiddleware(common.NewAPI())
+	registryID, err := ResolvePluginRegistryID(org, registryStr, m)
+	if err != nil {
+		return cobra.AppendActiveHelp(nil, "failed to resolve registry: "+err.Error()), cobra.ShellCompDirectiveNoFileComp
+	}
+	pluginID, err := ResolveRegistryPluginID(org, registryID, pluginStr, m)
+	if err != nil {
+		return cobra.AppendActiveHelp(nil, "failed to resolve plugin: "+err.Error()), cobra.ShellCompDirectiveNoFileComp
+	}
+	versions, _, err := m.ListPluginVersions(org, registryID, pluginID)
+	if err != nil {
+		return cobra.AppendActiveHelp(nil, "failed to list versions: "+err.Error()), cobra.ShellCompDirectiveNoFileComp
+	}
+	completions := make([]cobra.Completion, 0, len(versions))
+	for _, v := range versions {
+		if v.ID == nil {
+			continue
+		}
+		idStr := strconv.Itoa(int(*v.ID))
+		desc := ""
+		if v.Status != nil {
+			desc = *v.Status
+		}
+		completions = append(completions, cobra.CompletionWithDesc(idStr, desc))
+	}
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
 // CompleteRegistryPluginID offers ID and name completions for plugins within a registry.
 // The registry must already be resolved from args[0].
 func CompleteRegistryPluginID(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
@@ -374,5 +478,8 @@ func resolveUnique(kind, nameOrID string, matches []uint32) (uint32, error) {
 	}
 }
 
-// httpResponseToError is a no-op import guard for http in this file.
-var _ = (*http.Response)(nil)
+// IsNoMatchError returns true when err is the "no X found matching" sentinel
+// from resolveUnique, indicating the resource simply does not exist yet.
+func IsNoMatchError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "found matching")
+}

--- a/internal/cyout/errors.go
+++ b/internal/cyout/errors.go
@@ -29,11 +29,11 @@ type apiErrorPayloader interface {
 }
 
 var (
-	styleHeader    = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("9"))  // bold red
-	styleDim       = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))             // dim gray
-	styleEndpoint  = lipgloss.NewStyle().Foreground(lipgloss.Color("11"))            // yellow
-	styleCode      = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("8"))  // bold dim
-	styleCmdHint   = lipgloss.NewStyle().Foreground(lipgloss.Color("8")).Italic(true) // dim italic
+	styleHeader   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("9"))   // bold red
+	styleDim      = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))              // dim gray
+	styleEndpoint = lipgloss.NewStyle().Foreground(lipgloss.Color("11"))             // yellow
+	styleCode     = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("8"))   // bold dim
+	styleCmdHint  = lipgloss.NewStyle().Foreground(lipgloss.Color("8")).Italic(true) // dim italic
 )
 
 // printError writes a formatted error block to cmd's stderr.

--- a/internal/cyout/errors_test.go
+++ b/internal/cyout/errors_test.go
@@ -21,12 +21,12 @@ type fakeAPIError struct {
 	payload    *models.ErrorPayload
 }
 
-func (e *fakeAPIError) Error() string           { return "fake api error" }
-func (e *fakeAPIError) HTTPStatusCode() int     { return e.statusCode }
-func (e *fakeAPIError) HTTPRequestMethod() string { return e.method }
-func (e *fakeAPIError) HTTPRequestPath() string  { return e.path }
-func (e *fakeAPIError) HTTPRequestBody() []byte  { return e.reqBody }
-func (e *fakeAPIError) HTTPResponseBody() []byte { return e.respBody }
+func (e *fakeAPIError) Error() string                    { return "fake api error" }
+func (e *fakeAPIError) HTTPStatusCode() int              { return e.statusCode }
+func (e *fakeAPIError) HTTPRequestMethod() string        { return e.method }
+func (e *fakeAPIError) HTTPRequestPath() string          { return e.path }
+func (e *fakeAPIError) HTTPRequestBody() []byte          { return e.reqBody }
+func (e *fakeAPIError) HTTPResponseBody() []byte         { return e.respBody }
 func (e *fakeAPIError) GetPayload() *models.ErrorPayload { return e.payload }
 
 func ptrString(s string) *string { return &s }

--- a/pkg/testcfg/config.go
+++ b/pkg/testcfg/config.go
@@ -50,9 +50,9 @@ func NewConfig(testName string) (*Config, error) {
 			"-----END OPENSSH PRIVATE KEY-----",
 		}, "\n")
 		localGitCredential    = "local-git"
-		configRepoName   = "cli-test-config"
-		configRepository = "cli-test-config"
-		configRepoURL    = "git@git-server:/git-server/repos/backend-test-config-repo.git"
+		configRepoName        = "cli-test-config"
+		configRepository      = "cli-test-config"
+		configRepoURL         = "git@git-server:/git-server/repos/backend-test-config-repo.git"
 		configRepoBranch      = "master"
 		isDefault             = true
 		gitCred               = "github"

--- a/pkg/testcfg/plugins.go
+++ b/pkg/testcfg/plugins.go
@@ -1,0 +1,130 @@
+package testcfg
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cycloidio/cycloid-cli/client/models"
+)
+
+// NewTestPluginRegistry creates a plugin registry for testing and registers cleanup.
+// If a registry with the same URL already exists it is returned as-is (no cleanup
+// registered for it, since we don't own it).
+func (config *Config) NewTestPluginRegistry(t *testing.T, name, url string) (*models.PluginRegistry, error) {
+	t.Helper()
+	m := config.Middleware
+	out, _, err := m.CreatePluginRegistry(config.Org, name, url)
+	if err != nil {
+		// 409 Conflict → registry with this URL already exists; find and return it.
+		if strings.Contains(err.Error(), "409") || strings.Contains(err.Error(), "already exists") {
+			regs, _, listErr := m.ListPluginRegistries(config.Org)
+			if listErr != nil {
+				return nil, fmt.Errorf("create failed (%v) and list fallback failed: %w", err, listErr)
+			}
+			for _, r := range regs {
+				if r.URL != nil && string(*r.URL) == url {
+					return r, nil
+				}
+			}
+			return nil, fmt.Errorf("registry with url %q not found after 409: %w", url, err)
+		}
+		return nil, err
+	}
+	config.AppendCleanup(func() {
+		if _, delErr := m.DeletePluginRegistry(config.Org, *out.ID); delErr != nil {
+			log.Printf("failed to cleanup plugin registry %q: %v", name, delErr)
+		}
+	})
+	return out, nil
+}
+
+// NewTestPluginInRegistry creates a plugin inside the given registry and registers cleanup.
+func (config *Config) NewTestPluginInRegistry(t *testing.T, registryID uint32, name string) (*models.Plugin, error) {
+	t.Helper()
+	m := config.Middleware
+	out, _, err := m.CreateRegistryPlugin(config.Org, registryID, name)
+	if err != nil {
+		return nil, err
+	}
+	config.AppendCleanup(func() {
+		if _, err := m.DeleteRegistryPlugin(config.Org, registryID, *out.ID); err != nil {
+			log.Printf("failed to cleanup registry plugin %q: %v", name, err)
+		}
+	})
+	return out, nil
+}
+
+// NewTestPluginVersion publishes a plugin version, waits for it to reach "success"
+// status (indicating the plugin-registry has validated the image), and registers cleanup.
+func (config *Config) NewTestPluginVersion(t *testing.T, registryID, pluginID uint32, dockerImage string) (*models.PluginVersion, error) {
+	t.Helper()
+	m := config.Middleware
+	out, _, err := m.CreatePluginVersion(config.Org, registryID, pluginID, dockerImage)
+	if err != nil {
+		return nil, err
+	}
+	config.AppendCleanup(func() {
+		if _, delErr := m.DeletePluginVersion(config.Org, registryID, pluginID, *out.ID); delErr != nil {
+			log.Printf("failed to cleanup plugin version %d: %v", *out.ID, delErr)
+		}
+	})
+
+	// The plugin-registry validates the image asynchronously. Poll until success.
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		ver, _, pollErr := m.GetPluginVersion(config.Org, registryID, pluginID, *out.ID)
+		if pollErr == nil && ver.Status != nil {
+			switch *ver.Status {
+			case "success":
+				return ver, nil
+			case "failed":
+				return nil, fmt.Errorf("plugin version %d validation failed", *out.ID)
+			}
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return nil, fmt.Errorf("plugin version %d did not reach success within 60s", *out.ID)
+}
+
+// AcceptPluginManager finds and accepts the auto-registered test-plugin-manager.
+// The plugin-manager service in compose.yml auto-registers itself as "test-plugin-manager"
+// on startup, but retries if the org doesn't exist yet. This helper polls until it
+// appears (up to 90s) then accepts it.
+func (config *Config) AcceptPluginManager(t *testing.T) (*models.PluginManager, error) {
+	t.Helper()
+	m := config.Middleware
+	deadline := time.Now().Add(90 * time.Second)
+	for {
+		managers, _, listErr := m.ListPluginManagers(config.Org)
+		if listErr == nil {
+			for _, mgr := range managers {
+				if mgr.Name != nil && *mgr.Name == "test-plugin-manager" {
+					// "invite_accepted" is what the API returns once accepted.
+					// Either form means already done.
+					if mgr.InviteStatus != nil &&
+						(*mgr.InviteStatus == "accepted" || *mgr.InviteStatus == "invite_accepted") {
+						return mgr, nil
+					}
+					out, _, acceptErr := m.UpdatePluginManager(config.Org, *mgr.ID, "accepted")
+					if acceptErr != nil {
+						// Already accepted by a concurrent call — treat as success.
+						if strings.Contains(acceptErr.Error(), "only pending") {
+							return mgr, nil
+						}
+						return nil, acceptErr
+					}
+					return out, nil
+				}
+			}
+		}
+		// Any error (including JSON decode of numeric status on first registration)
+		// means the manager is not ready yet — keep polling.
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("test-plugin-manager did not register within 90s")
+		}
+		time.Sleep(5 * time.Second)
+	}
+}


### PR DESCRIPTION
## Summary

Full plugin management surface under `cy plugin`:

- **`cy plugin list/get`** — list and inspect installed plugins
- **`cy plugin uninstall <id-or-name>...`** — uninstall one or more plugins (variadic)
- **`cy plugin upgrade`** — upgrade a plugin version or update its config
- **`cy plugin logs [--watch] [--watch-interval]`** — stream deployment and runtime logs; `--watch` polls and prints only new entries
- **`cy plugin widget list/get/query`** — list widgets, inspect them, execute their pre-configured data query
- **`cy plugin registry`** — CRUD for plugin registries; `create` has `--update` for idempotent upsert
- **`cy plugin registry plugin version install --retry`** — install a version; `--retry` retries if already installed (CI-safe)
- **`cy plugin manager`** — manage plugin managers

Removed `cy plugin install` (was calling a non-existent API route — real install is via `cy plugin registry plugin version install`).

## Part of

This is **3 of 3** PRs split from #426. Stack:

1. `feat/output-system` — output system (#430)
2. `feat/command-behavior` — command migrations (#431)
3. **This PR** — plugin commands (base: PR 2)

## Closes

Closes #426

## Test plan

- [ ] `cy plugin list` — returns installed plugins
- [ ] `cy plugin logs <id> --watch` — polls and prints only new log lines; Ctrl-C stops cleanly
- [ ] `cy plugin registry plugin version install <reg> <plugin> <ver> --config k=v` — installs
- [ ] `cy plugin registry plugin version install <reg> <plugin> <ver> --retry` — second run succeeds (retries instead of failing)
- [ ] `cy plugin widget query <widget-id>` — returns query results
- [ ] `cy plugin uninstall a b` — uninstalls both

🤖 Generated with [Claude Code](https://claude.com/claude-code)