### PR TITLE
fix(buildwatch): preserve blank lines within multi-line log payloads

### DIFF
--- a/internal/buildwatch/format.go
+++ b/internal/buildwatch/format.go
@@ -219,6 +219,7 @@ func paintLogLines(source, payload string, t StreamTheme) string {
 	var b strings.Builder
 	for _, line := range lines {
 		if strings.TrimSpace(line) == "" {
+			b.WriteByte('\n')
 			continue
 		}
 		if t.Reset == "" {

--- a/internal/buildwatch/watch_test.go
+++ b/internal/buildwatch/watch_test.go
@@ -269,7 +269,7 @@ func TestFormatHumanBuildEventRawPassthroughInvalidJSON(t *testing.T) {
 	assert.Equal(t, "not-json\n", out)
 }
 
-func TestFormatHumanBuildEventLogSkipsEmptyAndWhitespaceLines(t *testing.T) {
+func TestFormatHumanBuildEventLogPreservesBlankLines(t *testing.T) {
 	t.Parallel()
 
 	opts := consumeOpts{
@@ -278,15 +278,18 @@ func TestFormatHumanBuildEventLogSkipsEmptyAndWhitespaceLines(t *testing.T) {
 		stripLogANSI: true,
 	}
 
+	// Blank lines within a payload are preserved as bare newlines so
+	// meaningful output separators (e.g. ls column groups) are not lost.
 	multi := `{"data":{"origin":{"source":"stdout"},"payload":"hello\n\n\nworld\n"},"event":"log","version":"1.0"}`
 	out, ok := formatHumanBuildEvent(multi, opts)
 	require.True(t, ok)
 	assert.Contains(t, out, "[stdout] hello")
 	assert.Contains(t, out, "[stdout] world")
-	assert.NotContains(t, out, "[stdout] \n")
-	lineCount := strings.Count(out, "[stdout]")
-	assert.Equal(t, 2, lineCount)
+	assert.NotContains(t, out, "[stdout] \n") // blank lines must not get the [stdout] prefix
+	assert.Equal(t, 2, strings.Count(out, "[stdout]"))
+	assert.Greater(t, strings.Count(out, "\n"), 2) // blank lines are present as bare newlines
 
+	// Fully-whitespace payloads are suppressed entirely.
 	emptyPayload := `{"data":{"origin":{"source":"stdout"},"payload":"\n"},"event":"log","version":"1.0"}`
 	_, ok = formatHumanBuildEvent(emptyPayload, opts)
 	assert.False(t, ok)


### PR DESCRIPTION
## Summary

- `paintLogLines` was skipping blank lines inside multi-line Concourse log payloads via an inner `continue`, dropping meaningful separators (e.g. columnar `ls` output split across groups)
- The outer `TrimSpace` guard already suppresses fully-whitespace-only payloads; the inner skip was redundant and lossy
- Now emits a bare `\n` for blank lines so the original structure of build output is preserved in `--watch` human mode

Fixes [CLI-119](https://linear.app/cycloid/issue/CLI-119)

## Test plan

- [x] `TestFormatHumanBuildEventLogPreservesBlankLines` — renamed and updated to assert blank lines appear as bare newlines and that no `[stdout]` prefix is added to them; fully-whitespace payloads still suppressed
- [x] All `./internal/buildwatch/...` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)