### PR TITLE
Add force flag to delete commands for project, environment, and component

### DIFF
--- a/changelog/unreleased/CLI-ADDED-20260515-111056.yaml
+++ b/changelog/unreleased/CLI-ADDED-20260515-111056.yaml
@@ -1,0 +1,8 @@
+component: CLI
+kind: ADDED
+body: Added delete options (skip-hooks, ignore-config-files-err) to delete component/environment/project
+time: 2026-05-15T11:10:56.466023954Z
+custom:
+  DETAILS: ""
+  PR: "440"
+  TYPE: CLI

--- a/cmd/cycloid/components/delete.go
+++ b/cmd/cycloid/components/delete.go
@@ -26,6 +26,7 @@ func NewDeleteComponentCommand() *cobra.Command {
 	cyargs.AddProjectFlag(cmd)
 	cyargs.AddEnvFlag(cmd)
 	cyargs.AddComponentFlag(cmd)
+	cyargs.AddDeleteFlags(cmd)
 	return cmd
 }
 
@@ -41,6 +42,11 @@ func deleteComponent(cmd *cobra.Command, args []string) error {
 	}
 
 	env, err := cyargs.GetEnv(cmd)
+	if err != nil {
+		return err
+	}
+
+	force, skipHooks, ignoreConfigFilesErr, err := cyargs.GetDeleteFlags(cmd)
 	if err != nil {
 		return err
 	}
@@ -63,10 +69,9 @@ func deleteComponent(cmd *cobra.Command, args []string) error {
 	api := common.NewAPI()
 	m := middleware.NewMiddleware(api)
 
-	components := args
-
-	for _, component := range components {
-		_, err = m.DeleteComponent(org, project, env, component)
+	opts := middleware.DeleteOptions{Force: force, SkipHooks: skipHooks, IgnoreConfigFilesErr: ignoreConfigFilesErr}
+	for _, component := range args {
+		_, err = m.DeleteComponent(org, project, env, component, opts)
 		if err != nil {
 			return cyout.Print(cmd, nil, err, "failed to delete component '"+component+"'")
 		}

--- a/cmd/cycloid/environments/delete.go
+++ b/cmd/cycloid/environments/delete.go
@@ -27,19 +27,22 @@ func NewDeleteCommand() *cobra.Command {
 
 	cyargs.AddProjectFlag(cmd)
 	cyargs.AddEnvFlag(cmd)
+	cyargs.AddDeleteFlags(cmd)
 	return cmd
 }
 
 func deleteEnvironment(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
 	if err != nil {
 		return err
 	}
 
 	project, err := cyargs.GetProject(cmd)
+	if err != nil {
+		return err
+	}
+
+	force, skipHooks, ignoreConfigFilesErr, err := cyargs.GetDeleteFlags(cmd)
 	if err != nil {
 		return err
 	}
@@ -59,10 +62,12 @@ func deleteEnvironment(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	envs := args
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
 
-	for _, env := range envs {
-		_, err = m.DeleteEnv(org, project, env)
+	opts := middleware.DeleteOptions{Force: force, SkipHooks: skipHooks, IgnoreConfigFilesErr: ignoreConfigFilesErr}
+	for _, env := range args {
+		_, err = m.DeleteEnv(org, project, env, opts)
 		if err != nil {
 			return cyout.Print(cmd, nil, err, "unable to delete environment "+env)
 		}

--- a/cmd/cycloid/middleware/http_client.go
+++ b/cmd/cycloid/middleware/http_client.go
@@ -42,6 +42,29 @@ type StackUseCase struct {
 	UseCase       *string `json:"use_case"`
 }
 
+// DeleteOptions carries the caller-facing flags for delete operations.
+// Force is sugar for enabling both SkipHooks and IgnoreConfigFilesErr.
+// Resolve expands Force before building the API query.
+type DeleteOptions struct {
+	Force                bool
+	SkipHooks            bool
+	IgnoreConfigFilesErr bool
+}
+
+// deleteQuery is the wire representation sent as URL query params.
+type deleteQuery struct {
+	SkipHooks            bool `url:"skip_hooks"`
+	IgnoreConfigFilesErr bool `url:"ignore_config_files_err"`
+}
+
+// Resolve returns the effective deleteQuery, merging Force into both fields.
+func (o DeleteOptions) Resolve() deleteQuery {
+	return deleteQuery{
+		SkipHooks:            o.SkipHooks || o.Force,
+		IgnoreConfigFilesErr: o.IgnoreConfigFilesErr || o.Force,
+	}
+}
+
 // Request represents an HTTP request to the Cycloid API.
 type Request struct {
 	Method       string

--- a/cmd/cycloid/middleware/lhs_filter_discovery_test.go
+++ b/cmd/cycloid/middleware/lhs_filter_discovery_test.go
@@ -35,11 +35,11 @@ func TestLHSFilterDiscovery(t *testing.T) {
 
 		_, _, err := m.CreateProject(org, nameA, projA, "desc a", configRepo, "", "", "default", "world")
 		require.NoError(t, err, "setup: create projA")
-		defer func() { _, _ = m.DeleteProject(org, projA) }()
+		defer func() { _, _ = m.DeleteProject(org, projA, middleware.DeleteOptions{}) }()
 
 		_, _, err = m.CreateProject(org, nameB, projB, "desc b", configRepo, "", "", "default", "world")
 		require.NoError(t, err, "setup: create projB")
-		defer func() { _, _ = m.DeleteProject(org, projB) }()
+		defer func() { _, _ = m.DeleteProject(org, projB, middleware.DeleteOptions{}) }()
 
 		t.Run("project_canonical[eq]", func(t *testing.T) {
 			results, _, err := m.ListProjects(org, middleware.LHSFilter{Attribute: "project_canonical", Condition: "eq", Value: projA})

--- a/cmd/cycloid/middleware/middleware.go
+++ b/cmd/cycloid/middleware/middleware.go
@@ -144,7 +144,7 @@ type Middleware interface {
 	// Project
 	CreateProject(org, projectName, project, description, configRepository, owner, team, color, icon string) (*models.Project, *http.Response, error)
 	UpdateProject(org, projectName, project, description, configRepository, owner, team, color, icon, cloudProvider string) (*models.Project, *http.Response, error)
-	DeleteProject(org, project string) (*http.Response, error)
+	DeleteProject(org, project string, opts DeleteOptions) (*http.Response, error)
 	GetProject(org string, project string) (*models.Project, *http.Response, error)
 	ListProjects(org string, filters ...LHSFilter) ([]*models.Project, *http.Response, error)
 	ListProjectsEnv(org, project string, filters ...LHSFilter) ([]*models.Environment, *http.Response, error)
@@ -153,14 +153,14 @@ type Middleware interface {
 	GetEnv(org, project, env string) (*models.Environment, *http.Response, error)
 	CreateEnv(org, project, env, envName, color string) (*models.Environment, *http.Response, error)
 	UpdateEnv(org, project, env, envName, color string) (*models.Environment, *http.Response, error)
-	DeleteEnv(org, project, env string) (*http.Response, error)
+	DeleteEnv(org, project, env string, opts DeleteOptions) (*http.Response, error)
 
 	// Component
 	CreateOrUpdateComponent(org, project, env, component, description, name, stackRef, versionTag, versionBranch, versionCommitHash, useCase, cloudProvider string, vars models.FormVariables) (*models.Component, *http.Response, error)
 	ListComponents(org, project, env string, filters ...LHSFilter) ([]*models.Component, *http.Response, error)
 	GetComponent(org, project, env, component string) (*models.Component, *http.Response, error)
 	MigrateComponent(org, project, env, component, targetProject, targetEnv, newCanonical, newName string) (*models.Component, *http.Response, error)
-	DeleteComponent(org, project, env, component string) (*http.Response, error)
+	DeleteComponent(org, project, env, component string, opts DeleteOptions) (*http.Response, error)
 	GetComponentConfig(org, project, env, component string) (models.FormVariables, *http.Response, error)
 	GetComponentStackConfig(org, project, env, component, useCase, versionTag, versionBranch, versionCommitHash string) (models.ServiceCatalogConfigs, *http.Response, error)
 

--- a/cmd/cycloid/middleware/organization_components.go
+++ b/cmd/cycloid/middleware/organization_components.go
@@ -127,13 +127,16 @@ func (m *middleware) MigrateComponent(org, project, env, component, targetProjec
 	return result, resp, nil
 }
 
-func (m *middleware) DeleteComponent(org, project, env, component string) (*http.Response, error) {
-	resp, err := m.GenericRequest(Request{
+func (m *middleware) DeleteComponent(org, project, env, component string, opts DeleteOptions) (*http.Response, error) {
+	req := Request{
 		Method:       "DELETE",
 		Organization: &org,
 		Route:        []string{"organizations", org, "projects", project, "environments", env, "components", component},
-	}, nil)
-	return resp, err
+	}
+	if q := opts.Resolve(); q.SkipHooks || q.IgnoreConfigFilesErr {
+		req.Query = q
+	}
+	return m.GenericRequest(req, nil)
 }
 
 func (m *middleware) GetComponentStackConfig(org, project, env, component, useCase, versionTag, versionBranch, versionCommitHash string) (models.ServiceCatalogConfigs, *http.Response, error) {

--- a/cmd/cycloid/middleware/organization_components_test.go
+++ b/cmd/cycloid/middleware/organization_components_test.go
@@ -101,7 +101,7 @@ func TestComponentCRUD(t *testing.T) {
 		}
 
 		defer func() {
-			_, err := m.DeleteComponent(config.Org, *config.Project.Canonical, *config.Environment.Canonical, *createdComponent.Canonical)
+			_, err := m.DeleteComponent(config.Org, *config.Project.Canonical, *config.Environment.Canonical, *createdComponent.Canonical, middleware.DeleteOptions{})
 			if err != nil {
 				log.Fatalf("Failed to delete component '%s': %v", *createdComponent.Canonical, err)
 				return

--- a/cmd/cycloid/middleware/organization_project_environment.go
+++ b/cmd/cycloid/middleware/organization_project_environment.go
@@ -63,11 +63,14 @@ func (m *middleware) UpdateEnv(org, project, env, envName, color string) (*model
 	return result, resp, nil
 }
 
-func (m *middleware) DeleteEnv(org, project, env string) (*http.Response, error) {
-	resp, err := m.GenericRequest(Request{
+func (m *middleware) DeleteEnv(org, project, env string, opts DeleteOptions) (*http.Response, error) {
+	req := Request{
 		Method:       "DELETE",
 		Organization: &org,
 		Route:        []string{"organizations", org, "projects", project, "environments", env},
-	}, nil)
-	return resp, err
+	}
+	if q := opts.Resolve(); q.SkipHooks || q.IgnoreConfigFilesErr {
+		req.Query = q
+	}
+	return m.GenericRequest(req, nil)
 }

--- a/cmd/cycloid/middleware/organization_project_environment_test.go
+++ b/cmd/cycloid/middleware/organization_project_environment_test.go
@@ -25,7 +25,7 @@ func TestEnvCrud(t *testing.T) {
 	)
 
 	defer func() {
-		_, err := m.DeleteProject(config.Org, project)
+		_, err := m.DeleteProject(config.Org, project, middleware.DeleteOptions{})
 		if err != nil {
 			log.Fatalf("Failed to decomission project '%s' from CRUD tests: %v", project, err)
 			return
@@ -52,7 +52,7 @@ func TestEnvCrud(t *testing.T) {
 
 	// delete
 	defer func() {
-		_, err := m.DeleteEnv(config.Org, *createdProject.Canonical, *createdEnv.Canonical)
+		_, err := m.DeleteEnv(config.Org, *createdProject.Canonical, *createdEnv.Canonical, middleware.DeleteOptions{})
 		if err != nil {
 			log.Fatalf("Failed to delete env '%s': %v", env, err)
 			return

--- a/cmd/cycloid/middleware/organization_projects.go
+++ b/cmd/cycloid/middleware/organization_projects.go
@@ -109,11 +109,14 @@ func (m *middleware) UpdateProject(org, projectName, project, description, confi
 	return result, resp, nil
 }
 
-func (m *middleware) DeleteProject(org, project string) (*http.Response, error) {
-	resp, err := m.GenericRequest(Request{
+func (m *middleware) DeleteProject(org, project string, opts DeleteOptions) (*http.Response, error) {
+	req := Request{
 		Method:       "DELETE",
 		Organization: &org,
 		Route:        []string{"organizations", org, "projects", project},
-	}, nil)
-	return resp, err
+	}
+	if q := opts.Resolve(); q.SkipHooks || q.IgnoreConfigFilesErr {
+		req.Query = q
+	}
+	return m.GenericRequest(req, nil)
 }

--- a/cmd/cycloid/middleware/organization_projects_test.go
+++ b/cmd/cycloid/middleware/organization_projects_test.go
@@ -32,7 +32,7 @@ func TestProjectCrud(t *testing.T) {
 	}
 
 	defer func() {
-		_, err := m.DeleteProject(config.Org, project)
+		_, err := m.DeleteProject(config.Org, project, middleware.DeleteOptions{})
 		if err != nil {
 			t.Errorf("Failed to delete project '%s': %v", project, err)
 		}

--- a/cmd/cycloid/projects/delete.go
+++ b/cmd/cycloid/projects/delete.go
@@ -31,14 +31,17 @@ func NewDeleteCommand() *cobra.Command {
 	}
 
 	cyargs.AddProjectFlag(cmd)
+	cyargs.AddDeleteFlags(cmd)
 	return cmd
 }
 
 func deleteProject(cmd *cobra.Command, args []string) error {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
 	org, err := cyargs.GetOrg(cmd)
+	if err != nil {
+		return err
+	}
+
+	force, skipHooks, ignoreConfigFilesErr, err := cyargs.GetDeleteFlags(cmd)
 	if err != nil {
 		return err
 	}
@@ -58,9 +61,13 @@ func deleteProject(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	opts := middleware.DeleteOptions{Force: force, SkipHooks: skipHooks, IgnoreConfigFilesErr: ignoreConfigFilesErr}
 	deleted := make([]string, 0, len(args))
 	for _, project := range args {
-		_, err = m.DeleteProject(org, project)
+		_, err = m.DeleteProject(org, project, opts)
 		if err != nil {
 			return cyout.PrintWithOptions(cmd, nil, err, "unable to delete project "+project, printer.Options{})
 		}

--- a/e2e/components_test.go
+++ b/e2e/components_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cycloidio/cycloid-cli/client/models"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
 )
 
 func TestComponentCmd(t *testing.T) {
@@ -375,7 +376,7 @@ func TestComponentCmd(t *testing.T) {
 			t.FailNow()
 		}
 		defer m.DeleteComponent(config.Org, *created.Project.Canonical,
-			*created.Environment.Canonical, *created.Canonical)
+			*created.Environment.Canonical, *created.Canonical, middleware.DeleteOptions{})
 
 		args := []string{
 			"--output", "json",
@@ -411,7 +412,7 @@ func TestComponentCmd(t *testing.T) {
 			t.FailNow()
 		}
 		defer m.DeleteComponent(config.Org, *created.Project.Canonical,
-			*created.Environment.Canonical, *created.Canonical)
+			*created.Environment.Canonical, *created.Canonical, middleware.DeleteOptions{})
 
 		args := []string{
 			"--output", "json",
@@ -448,7 +449,7 @@ func TestComponentCmd(t *testing.T) {
 			t.FailNow()
 		}
 		defer m.DeleteComponent(config.Org, *created.Project.Canonical,
-			*created.Environment.Canonical, *created.Canonical)
+			*created.Environment.Canonical, *created.Canonical, middleware.DeleteOptions{})
 
 		versionBefore := created.ServiceCatalog.Version
 

--- a/internal/cyargs/common.go
+++ b/internal/cyargs/common.go
@@ -448,6 +448,23 @@ func GetDescription(cmd *cobra.Command) (string, error) {
 	return description, nil
 }
 
+func AddDeleteFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("force", false, "shorthand for --skip-hooks --ignore-config-files-err")
+		cmd.Flags().Bool("skip-hooks", false, "skip component on_delete hooks (sets skip_hooks=true)")
+	cmd.Flags().Bool("ignore-config-files-err", false, "ignore possible errors on config repository update (sets ignore_config_files_err=true)")
+}
+
+func GetDeleteFlags(cmd *cobra.Command) (force, skipHooks, ignoreConfigFilesErr bool, err error) {
+	if force, err = cmd.Flags().GetBool("force"); err != nil {
+		return
+	}
+	if skipHooks, err = cmd.Flags().GetBool("skip-hooks"); err != nil {
+		return
+	}
+	ignoreConfigFilesErr, err = cmd.Flags().GetBool("ignore-config-files-err")
+	return
+}
+
 func GetOrg(cmd *cobra.Command) (string, error) {
 	org := v.GetString("org")
 	if org == "" {

--- a/internal/testcfg/config.go
+++ b/internal/testcfg/config.go
@@ -252,7 +252,7 @@ func (config *Config) NewTestProject(identifier string) (*models.Project, error)
 	}
 
 	config.AppendCleanup(func() {
-		_, err := m.DeleteProject(config.Org, project)
+		_, err := m.DeleteProject(config.Org, project, middleware.DeleteOptions{})
 		if err != nil {
 			log.Fatalf("cannot cleanup projet %q for test %q: %v", project, identifier, err)
 			return
@@ -279,7 +279,7 @@ func (config *Config) NewTestEnv(identifier, project string) (*models.Environmen
 	}
 
 	config.AppendCleanup(func() {
-		_, err := m.DeleteEnv(config.Org, project, env)
+		_, err := m.DeleteEnv(config.Org, project, env, middleware.DeleteOptions{})
 		if err != nil {
 			log.Fatalf("cannot cleanup env %q for test %q: %v", env, identifier, err)
 			return
@@ -327,7 +327,7 @@ func (config *Config) NewTestComponent(project, env, identifier, stackRef, useCa
 	}
 
 	config.AppendCleanup(func() {
-		if _, err := m.DeleteComponent(config.Org, project, env, component); err != nil {
+		if _, err := m.DeleteComponent(config.Org, project, env, component, middleware.DeleteOptions{}); err != nil {
 			log.Printf("failed to cleanup component for test %q: %v", identifier, err)
 		}
 	})

--- a/pkg/testcfg/config.go
+++ b/pkg/testcfg/config.go
@@ -256,7 +256,7 @@ func (config *Config) NewTestProject(identifier string) (*models.Project, error)
 	}
 
 	config.AppendCleanup(func() {
-		_, err := m.DeleteProject(config.Org, project)
+		_, err := m.DeleteProject(config.Org, project, middleware.DeleteOptions{})
 		if err != nil {
 			log.Fatalf("cannot cleanup projet %q for test %q: %v", project, identifier, err)
 			return
@@ -283,7 +283,7 @@ func (config *Config) NewTestEnv(identifier, project string) (*models.Environmen
 	}
 
 	config.AppendCleanup(func() {
-		_, err := m.DeleteEnv(config.Org, project, env)
+		_, err := m.DeleteEnv(config.Org, project, env, middleware.DeleteOptions{})
 		if err != nil {
 			log.Fatalf("cannot cleanup env %q for test %q: %v", env, identifier, err)
 			return
@@ -331,7 +331,7 @@ func (config *Config) NewTestComponent(project, env, identifier, stackRef, useCa
 	}
 
 	config.AppendCleanup(func() {
-		if _, err := m.DeleteComponent(config.Org, project, env, component); err != nil {
+		if _, err := m.DeleteComponent(config.Org, project, env, component, middleware.DeleteOptions{}); err != nil {
 			log.Printf("failed to cleanup component for test %q: %v", identifier, err)
 		}
 	})


### PR DESCRIPTION
When `--force` is passed, the DELETE request includes `skip_hooks=true` as a query parameter, allowing deletion to bypass  hooks.