### PR TITLE
fix(plugins): wire auto_register=true in plugin manager create (CLI-121)

### DIFF
--- a/cmd/cycloid/middleware/middleware.go
+++ b/cmd/cycloid/middleware/middleware.go
@@ -185,7 +185,7 @@ type Middleware interface {
 	// organization_plugin_managers
 	ListPluginManagers(org string) ([]*models.PluginManager, *http.Response, error)
 	GetPluginManager(org string, id uint32) (*models.PluginManager, *http.Response, error)
-	CreatePluginManager(org, name, url string) (*models.PluginManager, *http.Response, error)
+	CreatePluginManager(org, name, url string, autoRegister bool) (*models.PluginManager, *http.Response, error)
 	UpdatePluginManager(org string, id uint32, inviteStatus string) (*models.PluginManager, *http.Response, error)
 	DeletePluginManager(org string, id uint32) (*http.Response, error)
 

--- a/cmd/cycloid/middleware/plugins.go
+++ b/cmd/cycloid/middleware/plugins.go
@@ -42,11 +42,12 @@ func (m *middleware) GetPluginManager(org string, id uint32) (*models.PluginMana
 	return result, resp, nil
 }
 
-func (m *middleware) CreatePluginManager(org, name, url string) (*models.PluginManager, *http.Response, error) {
+func (m *middleware) CreatePluginManager(org, name, url string, autoRegister bool) (*models.PluginManager, *http.Response, error) {
 	u := strfmt.URI(url)
 	body := &models.NewPluginManager{
-		Name: &name,
-		URL:  &u,
+		AutoRegister: autoRegister,
+		Name:         &name,
+		URL:          &u,
 	}
 	var result *models.PluginManager
 	resp, err := m.GenericRequest(Request{

--- a/cmd/cycloid/plugins/manager/create.go
+++ b/cmd/cycloid/plugins/manager/create.go
@@ -17,7 +17,7 @@ func NewCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Args:  cobra.NoArgs,
-		Short: "Invite a plugin manager to the organization",
+		Short: "Register a plugin manager with the organization",
 		Example: `
   cy plugin manager create --name my-manager --url https://pm.example.com
   cy plugin manager create --name my-manager --url https://pm.example.com --update
@@ -77,6 +77,6 @@ func createPluginManager(cmd *cobra.Command, args []string) error {
 		return cyout.PrintWithOptions(cmd, result, err, "unable to get existing plugin manager", printer.Options{})
 	}
 
-	result, _, err := m.CreatePluginManager(org, name, url)
+	result, _, err := m.CreatePluginManager(org, name, url, true)
 	return cyout.PrintWithOptions(cmd, result, err, "unable to create plugin manager", printer.Options{})
 }


### PR DESCRIPTION
## Summary

- Set `AutoRegister: true` on `NewPluginManager` in the plugin manager create middleware so CLI/TF registrations hit `RegisterPluginManager` instead of the invite-only path
- Extend `CreatePluginManager` middleware signature with an `autoRegister` parameter (CLI create command passes `true`)
- Update `cy plugin manager create` short description to reflect full registration rather than invite-only

Fixes orphaned `invite_pending` plugin manager rows where Cycloid never contacted the Plugin Manager (CLI-121 / ENGBE-266).

## Test plan

- [ ] `go build ./...`
- [ ] `cy plugin manager create --name test --url https://pm.example.com` sends `auto_register: true` in POST body
- [ ] Created manager is fully registered (not stuck in `invite_pending` without PM contact)


Made with [Cursor](https://cursor.com)