### PR TITLE
fix(models): remove PluginManager.status integer workaround (CLI-122)

### DIFF
--- a/client/models/plugin_manager.go
+++ b/client/models/plugin_manager.go
@@ -244,37 +244,6 @@ func (m *PluginManager) ContextValidate(ctx context.Context, formats strfmt.Regi
 	return nil
 }
 
-// UnmarshalJSON implements json.Unmarshaler with a workaround for backends that
-// serialize the status field as an integer (iota) instead of a string. This is
-// a known API bug in v6.10.8-rc (fix is entities/plugin.go:83 in meta-gov-env).
-// TODO: remove after meta-gov-env merges to develop and swagger client is regenerated.
-func (m *PluginManager) UnmarshalJSON(b []byte) error {
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if statusRaw, ok := raw["status"]; ok && len(statusRaw) > 0 && statusRaw[0] != '"' {
-		var idx int
-		if err := json.Unmarshal(statusRaw, &idx); err == nil {
-			names := []string{"offline", "connected"}
-			if idx >= 0 && idx < len(names) {
-				raw["status"] = json.RawMessage(`"` + names[idx] + `"`)
-			}
-		}
-	}
-	normalized, err := json.Marshal(raw)
-	if err != nil {
-		return err
-	}
-	type alias PluginManager
-	var a alias
-	if err := json.Unmarshal(normalized, &a); err != nil {
-		return err
-	}
-	*m = PluginManager(a)
-	return nil
-}
-
 // MarshalBinary interface implementation
 func (m *PluginManager) MarshalBinary() ([]byte, error) {
 	if m == nil {


### PR DESCRIPTION
## Summary

- Removes `PluginManager.UnmarshalJSON` workaround added in v6.10.8 to tolerate `status` arriving as an integer
- Gate conditions are both met: `meta-gov-env` merged to develop (PR #5527, 2026-05-22) and swagger client regenerated (2026-05-25)
- The backend fix (`entities/plugin.go:83`) is live; integer serialization no longer occurs

## Changes

Single file: `client/models/plugin_manager.go` — remove the custom `UnmarshalJSON` method (31 lines). No logic change for any current backend.

## Test plan

- [x] `go build ./client/models/` — clean
- [x] `go vet ./...` — clean
- [ ] Plugin manager commands (`cy plugin manager list/get`) against a v6.10.8+ backend to confirm status deserializes correctly as a string

Closes CLI-122

🤖 Generated with [Claude Code](https://claude.com/claude-code)