### PR TITLE
feat(projects): remove default config-repo fetch from CLI (CLI-22)

### DIFF
--- a/cmd/cycloid/components/config_get.go
+++ b/cmd/cycloid/components/config_get.go
@@ -19,7 +19,7 @@ func NewComponentConfigGetCommand() *cobra.Command {
 		Example: "cy config get -p project -e env -c component",
 	}
 	cyargs.AddCyContext(cmd)
-	cmd.Flags().Uint32("service-catalog-source-version-id", 0, "service catalog source version ID (default: latest)")
+	cyargs.AddStackVersionFlags(cmd)
 	return cmd
 }
 
@@ -29,14 +29,14 @@ func getComponentConfig(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	versionID, err := cmd.Flags().GetUint32("service-catalog-source-version-id")
+	api := common.NewAPI()
+	m := middleware.NewMiddleware(api)
+
+	tag, branch, hash, err := cyargs.ResolveStackVersionArg(cmd, m, org, "")
 	if err != nil {
 		return err
 	}
 
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
-	config, _, err := m.GetComponentConfig(org, project, env, component, versionID)
+	config, _, err := m.GetComponentConfig(org, project, env, component, tag, branch, hash)
 	return cyout.PrintWithOptions(cmd, config, err, "failed to fetch config of component '"+component+"'", printer.Options{})
 }

--- a/cmd/cycloid/components/config_get.go
+++ b/cmd/cycloid/components/config_get.go
@@ -1,6 +1,10 @@
 package components
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/spf13/cobra"
 
 	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
@@ -32,11 +36,24 @@ func getComponentConfig(cmd *cobra.Command, args []string) error {
 	api := common.NewAPI()
 	m := middleware.NewMiddleware(api)
 
-	tag, branch, hash, err := cyargs.ResolveStackVersionArg(cmd, m, org, "")
-	if err != nil {
-		return err
+	// version:<id> passes the catalog version ID directly to the API, bypassing
+	// stack ref resolution. Useful when debugging a known version ID.
+	var tag, branch, hash string
+	var versionID uint32
+	rawVersion, _ := cmd.Flags().GetString("stack-version")
+	if idStr, ok := strings.CutPrefix(rawVersion, "version:"); ok {
+		id64, err := strconv.ParseUint(idStr, 10, 32)
+		if err != nil {
+			return fmt.Errorf("--stack-version=version:<id>: expected a numeric ID, got %q", idStr)
+		}
+		versionID = uint32(id64)
+	} else {
+		tag, branch, hash, err = cyargs.ResolveStackVersionArg(cmd, m, org, "")
+		if err != nil {
+			return err
+		}
 	}
 
-	config, _, err := m.GetComponentConfig(org, project, env, component, tag, branch, hash)
+	config, _, err := m.GetComponentConfig(org, project, env, component, tag, branch, hash, versionID)
 	return cyout.PrintWithOptions(cmd, config, err, "failed to fetch config of component '"+component+"'", printer.Options{})
 }

--- a/cmd/cycloid/components/config_get.go
+++ b/cmd/cycloid/components/config_get.go
@@ -19,6 +19,7 @@ func NewComponentConfigGetCommand() *cobra.Command {
 		Example: "cy config get -p project -e env -c component",
 	}
 	cyargs.AddCyContext(cmd)
+	cmd.Flags().Uint32("service-catalog-source-version-id", 0, "service catalog source version ID (default: latest)")
 	return cmd
 }
 
@@ -28,9 +29,14 @@ func getComponentConfig(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	versionID, err := cmd.Flags().GetUint32("service-catalog-source-version-id")
+	if err != nil {
+		return err
+	}
+
 	api := common.NewAPI()
 	m := middleware.NewMiddleware(api)
 
-	config, _, err := m.GetComponentConfig(org, project, env, component)
+	config, _, err := m.GetComponentConfig(org, project, env, component, versionID)
 	return cyout.PrintWithOptions(cmd, config, err, "failed to fetch config of component '"+component+"'", printer.Options{})
 }

--- a/cmd/cycloid/components/config_get.go
+++ b/cmd/cycloid/components/config_get.go
@@ -1,10 +1,6 @@
 package components
 
 import (
-	"fmt"
-	"strconv"
-	"strings"
-
 	"github.com/spf13/cobra"
 
 	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
@@ -36,18 +32,12 @@ func getComponentConfig(cmd *cobra.Command, args []string) error {
 	api := common.NewAPI()
 	m := middleware.NewMiddleware(api)
 
-	// version:<id> passes the catalog version ID directly to the API, bypassing
-	// stack ref resolution. Useful when debugging a known version ID.
 	var tag, branch, hash string
-	var versionID uint32
-	rawVersion, _ := cmd.Flags().GetString("stack-version")
-	if idStr, ok := strings.CutPrefix(rawVersion, "version:"); ok {
-		id64, err := strconv.ParseUint(idStr, 10, 32)
-		if err != nil {
-			return fmt.Errorf("--stack-version=version:<id>: expected a numeric ID, got %q", idStr)
-		}
-		versionID = uint32(id64)
-	} else {
+	versionID, ok, err := cyargs.GetStackVersionID(cmd)
+	if err != nil {
+		return err
+	}
+	if !ok {
 		tag, branch, hash, err = cyargs.ResolveStackVersionArg(cmd, m, org, "")
 		if err != nil {
 			return err

--- a/cmd/cycloid/components/create.go
+++ b/cmd/cycloid/components/create.go
@@ -100,7 +100,7 @@ func createComponent(cmd *cobra.Command, args []string) error {
 			// Fetch base forms value from current component
 			var currentConfig = make(models.FormVariables)
 			if currentComponent.UseCase != "" {
-				currentConfig, _, err = m.GetComponentConfig(org, project, env, component, 0)
+				currentConfig, _, err = m.GetComponentConfig(org, project, env, component, "", "", "")
 				if err != nil {
 					return cyout.PrintWithOptions(cmd, nil, err, "failed to update component '"+component+"', cannot get current config.", printer.Options{})
 				}

--- a/cmd/cycloid/components/create.go
+++ b/cmd/cycloid/components/create.go
@@ -100,7 +100,7 @@ func createComponent(cmd *cobra.Command, args []string) error {
 			// Fetch base forms value from current component
 			var currentConfig = make(models.FormVariables)
 			if currentComponent.UseCase != "" {
-				currentConfig, _, err = m.GetComponentConfig(org, project, env, component)
+				currentConfig, _, err = m.GetComponentConfig(org, project, env, component, 0)
 				if err != nil {
 					return cyout.PrintWithOptions(cmd, nil, err, "failed to update component '"+component+"', cannot get current config.", printer.Options{})
 				}

--- a/cmd/cycloid/components/create.go
+++ b/cmd/cycloid/components/create.go
@@ -100,7 +100,7 @@ func createComponent(cmd *cobra.Command, args []string) error {
 			// Fetch base forms value from current component
 			var currentConfig = make(models.FormVariables)
 			if currentComponent.UseCase != "" {
-				currentConfig, _, err = m.GetComponentConfig(org, project, env, component, "", "", "")
+				currentConfig, _, err = m.GetComponentConfig(org, project, env, component, "", "", "", 0)
 				if err != nil {
 					return cyout.PrintWithOptions(cmd, nil, err, "failed to update component '"+component+"', cannot get current config.", printer.Options{})
 				}

--- a/cmd/cycloid/components/update.go
+++ b/cmd/cycloid/components/update.go
@@ -116,7 +116,7 @@ func updateComponent(cmd *cobra.Command, args []string) error {
 
 	var currentConfig = make(models.FormVariables)
 	if currentComponent.UseCase != "" {
-		currentConfig, _, err = m.GetComponentConfig(org, project, env, component, 0)
+		currentConfig, _, err = m.GetComponentConfig(org, project, env, component, "", "", "")
 		if err != nil {
 			return cyout.PrintWithOptions(cmd, nil, err, "failed to update component '"+component+"', cannot get current config.", printer.Options{})
 		}

--- a/cmd/cycloid/components/update.go
+++ b/cmd/cycloid/components/update.go
@@ -116,7 +116,7 @@ func updateComponent(cmd *cobra.Command, args []string) error {
 
 	var currentConfig = make(models.FormVariables)
 	if currentComponent.UseCase != "" {
-		currentConfig, _, err = m.GetComponentConfig(org, project, env, component, "", "", "")
+		currentConfig, _, err = m.GetComponentConfig(org, project, env, component, "", "", "", 0)
 		if err != nil {
 			return cyout.PrintWithOptions(cmd, nil, err, "failed to update component '"+component+"', cannot get current config.", printer.Options{})
 		}

--- a/cmd/cycloid/components/update.go
+++ b/cmd/cycloid/components/update.go
@@ -116,7 +116,7 @@ func updateComponent(cmd *cobra.Command, args []string) error {
 
 	var currentConfig = make(models.FormVariables)
 	if currentComponent.UseCase != "" {
-		currentConfig, _, err = m.GetComponentConfig(org, project, env, component)
+		currentConfig, _, err = m.GetComponentConfig(org, project, env, component, 0)
 		if err != nil {
 			return cyout.PrintWithOptions(cmd, nil, err, "failed to update component '"+component+"', cannot get current config.", printer.Options{})
 		}

--- a/cmd/cycloid/middleware/middleware.go
+++ b/cmd/cycloid/middleware/middleware.go
@@ -180,7 +180,7 @@ type Middleware interface {
 	GetComponent(org, project, env, component string) (*models.Component, *http.Response, error)
 	MigrateComponent(org, project, env, component, targetProject, targetEnv, newCanonical, newName string) (*models.Component, *http.Response, error)
 	DeleteComponent(org, project, env, component string, opts DeleteOptions) (*http.Response, error)
-	GetComponentConfig(org, project, env, component, versionTag, versionBranch, versionCommitHash string) (models.FormVariables, *http.Response, error)
+	GetComponentConfig(org, project, env, component, versionTag, versionBranch, versionCommitHash string, versionID uint32) (models.FormVariables, *http.Response, error)
 	GetComponentStackConfig(org, project, env, component, useCase, versionTag, versionBranch, versionCommitHash string) (models.ServiceCatalogConfigs, *http.Response, error)
 
 	DeleteRole(org, role string) (*http.Response, error)

--- a/cmd/cycloid/middleware/middleware.go
+++ b/cmd/cycloid/middleware/middleware.go
@@ -180,7 +180,7 @@ type Middleware interface {
 	GetComponent(org, project, env, component string) (*models.Component, *http.Response, error)
 	MigrateComponent(org, project, env, component, targetProject, targetEnv, newCanonical, newName string) (*models.Component, *http.Response, error)
 	DeleteComponent(org, project, env, component string, opts DeleteOptions) (*http.Response, error)
-	GetComponentConfig(org, project, env, component string) (models.FormVariables, *http.Response, error)
+	GetComponentConfig(org, project, env, component string, versionID uint32) (models.FormVariables, *http.Response, error)
 	GetComponentStackConfig(org, project, env, component, useCase, versionTag, versionBranch, versionCommitHash string) (models.ServiceCatalogConfigs, *http.Response, error)
 
 	DeleteRole(org, role string) (*http.Response, error)

--- a/cmd/cycloid/middleware/middleware.go
+++ b/cmd/cycloid/middleware/middleware.go
@@ -180,7 +180,7 @@ type Middleware interface {
 	GetComponent(org, project, env, component string) (*models.Component, *http.Response, error)
 	MigrateComponent(org, project, env, component, targetProject, targetEnv, newCanonical, newName string) (*models.Component, *http.Response, error)
 	DeleteComponent(org, project, env, component string, opts DeleteOptions) (*http.Response, error)
-	GetComponentConfig(org, project, env, component string, versionID uint32) (models.FormVariables, *http.Response, error)
+	GetComponentConfig(org, project, env, component, versionTag, versionBranch, versionCommitHash string) (models.FormVariables, *http.Response, error)
 	GetComponentStackConfig(org, project, env, component, useCase, versionTag, versionBranch, versionCommitHash string) (models.ServiceCatalogConfigs, *http.Response, error)
 
 	DeleteRole(org, role string) (*http.Response, error)

--- a/cmd/cycloid/middleware/offline/component_config_test.go
+++ b/cmd/cycloid/middleware/offline/component_config_test.go
@@ -1,7 +1,7 @@
 package offline_test
 
 import (
-	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,72 +12,9 @@ import (
 
 	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
 	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware/offline/mockserver"
 )
 
-// componentConfigServer builds a test server that mocks the resolution chain for
-// GetComponentConfig. It returns the stack version whose (type, name) matches
-// wantType/wantName for explicit resolution, or returns the branch head when
-// catalogRepoBranch matches a branch-type version (default/auto-resolve path).
-func componentConfigServer(t *testing.T, capturedQuery *string) *httptest.Server {
-	t.Helper()
-	const (
-		stackRef   = "myorg:my-stack"
-		catRepo    = "my-catalog-repo"
-		branchName = "main"
-		branchID   = uint32(99)
-		tagName    = "v1.2.3"
-		tagID      = uint32(77)
-	)
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		path := r.URL.Path
-
-		writeJSON := func(v any) {
-			_ = json.NewEncoder(w).Encode(map[string]any{"data": v})
-		}
-
-		switch {
-		case strings.HasSuffix(path, "/components/mycomp/config"):
-			*capturedQuery = r.URL.RawQuery
-			writeJSON(map[string]any{})
-
-		case strings.HasSuffix(path, "/components/mycomp"):
-			writeJSON(map[string]any{
-				"service_catalog": map[string]any{
-					"ref":                              stackRef,
-					"service_catalog_source_canonical": catRepo,
-				},
-			})
-
-		case strings.Contains(path, "service_catalogs") && strings.HasSuffix(path, "/versions"):
-			writeJSON([]map[string]any{
-				{"id": branchID, "type": "branch", "name": branchName, "commit_hash": "abc123"},
-				{"id": tagID, "type": "tag", "name": tagName, "commit_hash": "def456"},
-			})
-
-		case strings.Contains(path, "service_catalogs"):
-			writeJSON(map[string]any{
-				"ref":                              stackRef,
-				"service_catalog_source_canonical": catRepo,
-			})
-
-		case strings.Contains(path, "service_catalog_sources"):
-			writeJSON(map[string]any{
-				"canonical": catRepo,
-				"branch":    branchName,
-			})
-
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	return srv
-}
-
-// TestGetComponentConfig_RawVersionID verifies that when a non-zero versionID is
-// provided (from --stack-version=version:<id>), GetComponentConfig sends it directly
-// to the config endpoint with no extra resolution API calls.
 func TestGetComponentConfig_RawVersionID(t *testing.T) {
 	var capturedQuery string
 	callCount := 0
@@ -96,49 +33,39 @@ func TestGetComponentConfig_RawVersionID(t *testing.T) {
 
 	_, _, err := m.GetComponentConfig("org", "proj", "env", "comp", "", "", "", 14)
 	require.NoError(t, err)
-	assert.Equal(t, "service_catalog_source_version_id=14", capturedQuery,
-		"raw version ID 14 must be passed directly without resolution")
+	assert.Equal(t, "service_catalog_source_version_id=14", capturedQuery)
 	assert.Equal(t, 1, callCount, "raw version ID must not trigger extra API calls")
 }
 
-// TestGetComponentConfig_BranchResolvesVersion verifies that passing an explicit
-// branch name resolves to that branch's version ID in the config request.
 func TestGetComponentConfig_BranchResolvesVersion(t *testing.T) {
 	var capturedQuery string
-	srv := componentConfigServer(t, &capturedQuery)
+	srv := mockserver.ComponentConfigServer(t, &capturedQuery)
 	defer srv.Close()
 
 	api := common.NewAPI(common.WithURL(srv.URL), common.WithToken("test-token"))
 	m := middleware.NewMiddleware(api)
 
-	_, _, err := m.GetComponentConfig("myorg", "myproj", "myenv", "mycomp", "", "main", "", 0)
+	_, _, err := m.GetComponentConfig("myorg", "myproj", "myenv", "mycomp", "", mockserver.BranchName, "", 0)
 	require.NoError(t, err)
-	assert.Equal(t, "service_catalog_source_version_id=99", capturedQuery,
-		"branch 'main' should resolve to ID 99")
+	assert.Equal(t, fmt.Sprintf("service_catalog_source_version_id=%d", mockserver.BranchVersionID), capturedQuery)
 }
 
-// TestGetComponentConfig_TagResolvesVersion verifies that passing a tag name
-// resolves to that tag's version ID in the config request.
 func TestGetComponentConfig_TagResolvesVersion(t *testing.T) {
 	var capturedQuery string
-	srv := componentConfigServer(t, &capturedQuery)
+	srv := mockserver.ComponentConfigServer(t, &capturedQuery)
 	defer srv.Close()
 
 	api := common.NewAPI(common.WithURL(srv.URL), common.WithToken("test-token"))
 	m := middleware.NewMiddleware(api)
 
-	_, _, err := m.GetComponentConfig("myorg", "myproj", "myenv", "mycomp", "v1.2.3", "", "", 0)
+	_, _, err := m.GetComponentConfig("myorg", "myproj", "myenv", "mycomp", mockserver.TagName, "", "", 0)
 	require.NoError(t, err)
-	assert.Equal(t, "service_catalog_source_version_id=77", capturedQuery,
-		"tag 'v1.2.3' should resolve to ID 77")
+	assert.Equal(t, fmt.Sprintf("service_catalog_source_version_id=%d", mockserver.TagVersionID), capturedQuery)
 }
 
-// TestGetComponentConfig_AutoResolvesLatestVersion verifies that when no version
-// is specified, GetComponentConfig resolves the catalog-repo branch head and
-// passes the corresponding service_catalog_source_version_id to the config endpoint.
 func TestGetComponentConfig_AutoResolvesLatestVersion(t *testing.T) {
 	var capturedQuery string
-	srv := componentConfigServer(t, &capturedQuery)
+	srv := mockserver.ComponentConfigServer(t, &capturedQuery)
 	defer srv.Close()
 
 	api := common.NewAPI(common.WithURL(srv.URL), common.WithToken("test-token"))
@@ -146,6 +73,5 @@ func TestGetComponentConfig_AutoResolvesLatestVersion(t *testing.T) {
 
 	_, _, err := m.GetComponentConfig("myorg", "myproj", "myenv", "mycomp", "", "", "", 0)
 	require.NoError(t, err)
-	assert.Equal(t, "service_catalog_source_version_id=99", capturedQuery,
-		"default (no version specified) should resolve to catalog branch head ID 99")
+	assert.Equal(t, fmt.Sprintf("service_catalog_source_version_id=%d", mockserver.BranchVersionID), capturedQuery)
 }

--- a/cmd/cycloid/middleware/offline/component_config_test.go
+++ b/cmd/cycloid/middleware/offline/component_config_test.go
@@ -75,6 +75,32 @@ func componentConfigServer(t *testing.T, capturedQuery *string) *httptest.Server
 	return srv
 }
 
+// TestGetComponentConfig_RawVersionID verifies that when a non-zero versionID is
+// provided (from --stack-version=version:<id>), GetComponentConfig sends it directly
+// to the config endpoint with no extra resolution API calls.
+func TestGetComponentConfig_RawVersionID(t *testing.T) {
+	var capturedQuery string
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/config") {
+			capturedQuery = r.URL.RawQuery
+		}
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+	defer srv.Close()
+
+	api := common.NewAPI(common.WithURL(srv.URL), common.WithToken("test-token"))
+	m := middleware.NewMiddleware(api)
+
+	_, _, err := m.GetComponentConfig("org", "proj", "env", "comp", "", "", "", 14)
+	require.NoError(t, err)
+	assert.Equal(t, "service_catalog_source_version_id=14", capturedQuery,
+		"raw version ID 14 must be passed directly without resolution")
+	assert.Equal(t, 1, callCount, "raw version ID must not trigger extra API calls")
+}
+
 // TestGetComponentConfig_BranchResolvesVersion verifies that passing an explicit
 // branch name resolves to that branch's version ID in the config request.
 func TestGetComponentConfig_BranchResolvesVersion(t *testing.T) {
@@ -85,7 +111,7 @@ func TestGetComponentConfig_BranchResolvesVersion(t *testing.T) {
 	api := common.NewAPI(common.WithURL(srv.URL), common.WithToken("test-token"))
 	m := middleware.NewMiddleware(api)
 
-	_, _, err := m.GetComponentConfig("myorg", "myproj", "myenv", "mycomp", "", "main", "")
+	_, _, err := m.GetComponentConfig("myorg", "myproj", "myenv", "mycomp", "", "main", "", 0)
 	require.NoError(t, err)
 	assert.Equal(t, "service_catalog_source_version_id=99", capturedQuery,
 		"branch 'main' should resolve to ID 99")
@@ -101,7 +127,7 @@ func TestGetComponentConfig_TagResolvesVersion(t *testing.T) {
 	api := common.NewAPI(common.WithURL(srv.URL), common.WithToken("test-token"))
 	m := middleware.NewMiddleware(api)
 
-	_, _, err := m.GetComponentConfig("myorg", "myproj", "myenv", "mycomp", "v1.2.3", "", "")
+	_, _, err := m.GetComponentConfig("myorg", "myproj", "myenv", "mycomp", "v1.2.3", "", "", 0)
 	require.NoError(t, err)
 	assert.Equal(t, "service_catalog_source_version_id=77", capturedQuery,
 		"tag 'v1.2.3' should resolve to ID 77")
@@ -118,7 +144,7 @@ func TestGetComponentConfig_AutoResolvesLatestVersion(t *testing.T) {
 	api := common.NewAPI(common.WithURL(srv.URL), common.WithToken("test-token"))
 	m := middleware.NewMiddleware(api)
 
-	_, _, err := m.GetComponentConfig("myorg", "myproj", "myenv", "mycomp", "", "", "")
+	_, _, err := m.GetComponentConfig("myorg", "myproj", "myenv", "mycomp", "", "", "", 0)
 	require.NoError(t, err)
 	assert.Equal(t, "service_catalog_source_version_id=99", capturedQuery,
 		"default (no version specified) should resolve to catalog branch head ID 99")

--- a/cmd/cycloid/middleware/offline/component_config_test.go
+++ b/cmd/cycloid/middleware/offline/component_config_test.go
@@ -14,47 +14,20 @@ import (
 	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
 )
 
-// TestGetComponentConfig_ExplicitVersionID verifies that when an explicit versionID is
-// provided, GetComponentConfig sends exactly ?service_catalog_source_version_id=<id>
-// without any extra resolution calls.
-func TestGetComponentConfig_ExplicitVersionID(t *testing.T) {
-	var capturedQuery string
-	callCount := 0
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
-		w.Header().Set("Content-Type", "application/json")
-		if strings.HasSuffix(r.URL.Path, "/config") {
-			capturedQuery = r.URL.RawQuery
-		}
-		_, _ = w.Write([]byte(`{"data":{}}`))
-	}))
-	defer srv.Close()
-
-	api := common.NewAPI(common.WithURL(srv.URL), common.WithToken("test-token"))
-	m := middleware.NewMiddleware(api)
-
-	_, _, err := m.GetComponentConfig("org", "proj", "env", "comp", 42)
-	require.NoError(t, err)
-	assert.Equal(t, "service_catalog_source_version_id=42", capturedQuery)
-	assert.Equal(t, 1, callCount, "explicit version ID must not trigger extra API calls")
-}
-
-// TestGetComponentConfig_AutoResolvesLatestVersion verifies that when versionID == 0,
-// GetComponentConfig resolves the component's latest stack version and passes the
-// resolved service_catalog_source_version_id to the config endpoint.
-func TestGetComponentConfig_AutoResolvesLatestVersion(t *testing.T) {
+// componentConfigServer builds a test server that mocks the resolution chain for
+// GetComponentConfig. It returns the stack version whose (type, name) matches
+// wantType/wantName for explicit resolution, or returns the branch head when
+// catalogRepoBranch matches a branch-type version (default/auto-resolve path).
+func componentConfigServer(t *testing.T, capturedQuery *string) *httptest.Server {
+	t.Helper()
 	const (
-		org       = "myorg"
-		project   = "myproj"
-		env       = "prod"
-		component = "mycomp"
-		stackRef  = "myorg:my-stack"
-		catRepo   = "my-catalog-repo"
-		branch    = "main"
-		wantID    = uint32(99)
+		stackRef   = "myorg:my-stack"
+		catRepo    = "my-catalog-repo"
+		branchName = "main"
+		branchID   = uint32(99)
+		tagName    = "v1.2.3"
+		tagID      = uint32(77)
 	)
-
-	var capturedConfigQuery string
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -65,11 +38,11 @@ func TestGetComponentConfig_AutoResolvesLatestVersion(t *testing.T) {
 		}
 
 		switch {
-		case strings.HasSuffix(path, "/components/"+component+"/config"):
-			capturedConfigQuery = r.URL.RawQuery
+		case strings.HasSuffix(path, "/components/mycomp/config"):
+			*capturedQuery = r.URL.RawQuery
 			writeJSON(map[string]any{})
 
-		case strings.HasSuffix(path, "/components/"+component):
+		case strings.HasSuffix(path, "/components/mycomp"):
 			writeJSON(map[string]any{
 				"service_catalog": map[string]any{
 					"ref":                              stackRef,
@@ -79,7 +52,8 @@ func TestGetComponentConfig_AutoResolvesLatestVersion(t *testing.T) {
 
 		case strings.Contains(path, "service_catalogs") && strings.HasSuffix(path, "/versions"):
 			writeJSON([]map[string]any{
-				{"id": wantID, "type": "branch", "name": branch, "commit_hash": "abc123def456"},
+				{"id": branchID, "type": "branch", "name": branchName, "commit_hash": "abc123"},
+				{"id": tagID, "type": "tag", "name": tagName, "commit_hash": "def456"},
 			})
 
 		case strings.Contains(path, "service_catalogs"):
@@ -91,20 +65,61 @@ func TestGetComponentConfig_AutoResolvesLatestVersion(t *testing.T) {
 		case strings.Contains(path, "service_catalog_sources"):
 			writeJSON(map[string]any{
 				"canonical": catRepo,
-				"branch":    branch,
+				"branch":    branchName,
 			})
 
 		default:
 			http.NotFound(w, r)
 		}
 	}))
+	return srv
+}
+
+// TestGetComponentConfig_BranchResolvesVersion verifies that passing an explicit
+// branch name resolves to that branch's version ID in the config request.
+func TestGetComponentConfig_BranchResolvesVersion(t *testing.T) {
+	var capturedQuery string
+	srv := componentConfigServer(t, &capturedQuery)
 	defer srv.Close()
 
 	api := common.NewAPI(common.WithURL(srv.URL), common.WithToken("test-token"))
 	m := middleware.NewMiddleware(api)
 
-	_, _, err := m.GetComponentConfig(org, project, env, component, 0)
+	_, _, err := m.GetComponentConfig("myorg", "myproj", "myenv", "mycomp", "", "main", "")
 	require.NoError(t, err)
-	assert.Equal(t, "service_catalog_source_version_id=99", capturedConfigQuery,
-		"auto-resolve must pass the resolved version ID (99) to the config endpoint")
+	assert.Equal(t, "service_catalog_source_version_id=99", capturedQuery,
+		"branch 'main' should resolve to ID 99")
+}
+
+// TestGetComponentConfig_TagResolvesVersion verifies that passing a tag name
+// resolves to that tag's version ID in the config request.
+func TestGetComponentConfig_TagResolvesVersion(t *testing.T) {
+	var capturedQuery string
+	srv := componentConfigServer(t, &capturedQuery)
+	defer srv.Close()
+
+	api := common.NewAPI(common.WithURL(srv.URL), common.WithToken("test-token"))
+	m := middleware.NewMiddleware(api)
+
+	_, _, err := m.GetComponentConfig("myorg", "myproj", "myenv", "mycomp", "v1.2.3", "", "")
+	require.NoError(t, err)
+	assert.Equal(t, "service_catalog_source_version_id=77", capturedQuery,
+		"tag 'v1.2.3' should resolve to ID 77")
+}
+
+// TestGetComponentConfig_AutoResolvesLatestVersion verifies that when no version
+// is specified, GetComponentConfig resolves the catalog-repo branch head and
+// passes the corresponding service_catalog_source_version_id to the config endpoint.
+func TestGetComponentConfig_AutoResolvesLatestVersion(t *testing.T) {
+	var capturedQuery string
+	srv := componentConfigServer(t, &capturedQuery)
+	defer srv.Close()
+
+	api := common.NewAPI(common.WithURL(srv.URL), common.WithToken("test-token"))
+	m := middleware.NewMiddleware(api)
+
+	_, _, err := m.GetComponentConfig("myorg", "myproj", "myenv", "mycomp", "", "", "")
+	require.NoError(t, err)
+	assert.Equal(t, "service_catalog_source_version_id=99", capturedQuery,
+		"default (no version specified) should resolve to catalog branch head ID 99")
 }

--- a/cmd/cycloid/middleware/offline/component_config_test.go
+++ b/cmd/cycloid/middleware/offline/component_config_test.go
@@ -1,0 +1,110 @@
+package offline_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
+	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
+)
+
+// TestGetComponentConfig_ExplicitVersionID verifies that when an explicit versionID is
+// provided, GetComponentConfig sends exactly ?service_catalog_source_version_id=<id>
+// without any extra resolution calls.
+func TestGetComponentConfig_ExplicitVersionID(t *testing.T) {
+	var capturedQuery string
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/config") {
+			capturedQuery = r.URL.RawQuery
+		}
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+	defer srv.Close()
+
+	api := common.NewAPI(common.WithURL(srv.URL), common.WithToken("test-token"))
+	m := middleware.NewMiddleware(api)
+
+	_, _, err := m.GetComponentConfig("org", "proj", "env", "comp", 42)
+	require.NoError(t, err)
+	assert.Equal(t, "service_catalog_source_version_id=42", capturedQuery)
+	assert.Equal(t, 1, callCount, "explicit version ID must not trigger extra API calls")
+}
+
+// TestGetComponentConfig_AutoResolvesLatestVersion verifies that when versionID == 0,
+// GetComponentConfig resolves the component's latest stack version and passes the
+// resolved service_catalog_source_version_id to the config endpoint.
+func TestGetComponentConfig_AutoResolvesLatestVersion(t *testing.T) {
+	const (
+		org       = "myorg"
+		project   = "myproj"
+		env       = "prod"
+		component = "mycomp"
+		stackRef  = "myorg:my-stack"
+		catRepo   = "my-catalog-repo"
+		branch    = "main"
+		wantID    = uint32(99)
+	)
+
+	var capturedConfigQuery string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+
+		writeJSON := func(v any) {
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": v})
+		}
+
+		switch {
+		case strings.HasSuffix(path, "/components/"+component+"/config"):
+			capturedConfigQuery = r.URL.RawQuery
+			writeJSON(map[string]any{})
+
+		case strings.HasSuffix(path, "/components/"+component):
+			writeJSON(map[string]any{
+				"service_catalog": map[string]any{
+					"ref":                              stackRef,
+					"service_catalog_source_canonical": catRepo,
+				},
+			})
+
+		case strings.Contains(path, "service_catalogs") && strings.HasSuffix(path, "/versions"):
+			writeJSON([]map[string]any{
+				{"id": wantID, "type": "branch", "name": branch, "commit_hash": "abc123def456"},
+			})
+
+		case strings.Contains(path, "service_catalogs"):
+			writeJSON(map[string]any{
+				"ref":                              stackRef,
+				"service_catalog_source_canonical": catRepo,
+			})
+
+		case strings.Contains(path, "service_catalog_sources"):
+			writeJSON(map[string]any{
+				"canonical": catRepo,
+				"branch":    branch,
+			})
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	api := common.NewAPI(common.WithURL(srv.URL), common.WithToken("test-token"))
+	m := middleware.NewMiddleware(api)
+
+	_, _, err := m.GetComponentConfig(org, project, env, component, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "service_catalog_source_version_id=99", capturedConfigQuery,
+		"auto-resolve must pass the resolved version ID (99) to the config endpoint")
+}

--- a/cmd/cycloid/middleware/offline/mockserver/mockserver.go
+++ b/cmd/cycloid/middleware/offline/mockserver/mockserver.go
@@ -1,0 +1,70 @@
+package mockserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Version IDs and names served by ComponentConfigServer.
+const (
+	BranchVersionID = uint32(99)
+	TagVersionID    = uint32(77)
+	BranchName      = "main"
+	TagName         = "v1.2.3"
+	StackRef        = "myorg:my-stack"
+	CatalogRepo     = "my-catalog-repo"
+)
+
+// ComponentConfigServer returns a test server that mocks the full resolution chain
+// for GetComponentConfig: GetComponent → GetStack → GetCatalogRepository →
+// ListStackVersions → config GET. The capturedQuery pointer receives the raw query
+// string of the final config request.
+func ComponentConfigServer(t *testing.T, capturedQuery *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+
+		writeJSON := func(v any) {
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": v})
+		}
+
+		switch {
+		case strings.HasSuffix(path, "/components/mycomp/config"):
+			*capturedQuery = r.URL.RawQuery
+			writeJSON(map[string]any{})
+
+		case strings.HasSuffix(path, "/components/mycomp"):
+			writeJSON(map[string]any{
+				"service_catalog": map[string]any{
+					"ref":                              StackRef,
+					"service_catalog_source_canonical": CatalogRepo,
+				},
+			})
+
+		case strings.Contains(path, "service_catalogs") && strings.HasSuffix(path, "/versions"):
+			writeJSON([]map[string]any{
+				{"id": BranchVersionID, "type": "branch", "name": BranchName, "commit_hash": "abc123"},
+				{"id": TagVersionID, "type": "tag", "name": TagName, "commit_hash": "def456"},
+			})
+
+		case strings.Contains(path, "service_catalogs"):
+			writeJSON(map[string]any{
+				"ref":                              StackRef,
+				"service_catalog_source_canonical": CatalogRepo,
+			})
+
+		case strings.Contains(path, "service_catalog_sources"):
+			writeJSON(map[string]any{
+				"canonical": CatalogRepo,
+				"branch":    BranchName,
+			})
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}

--- a/cmd/cycloid/middleware/organization_components.go
+++ b/cmd/cycloid/middleware/organization_components.go
@@ -14,9 +14,6 @@ func (m *middleware) GetComponentConfig(org, project, env, component, versionTag
 	var result models.FormVariables
 
 	if versionID == 0 {
-		// Resolve component's stack ref to find the right catalog version.
-		// When all version args are empty this returns the default (latest branch head),
-		// matching console behavior (?service_catalog_source_version_id=<latest>).
 		comp, _, err := m.GetComponent(org, project, env, component)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get component to resolve stack version: %w", err)

--- a/cmd/cycloid/middleware/organization_components.go
+++ b/cmd/cycloid/middleware/organization_components.go
@@ -10,21 +10,19 @@ import (
 	"github.com/cycloidio/cycloid-cli/internal/ptr"
 )
 
-func (m *middleware) GetComponentConfig(org, project, env, component string, versionID uint32) (models.FormVariables, *http.Response, error) {
+func (m *middleware) GetComponentConfig(org, project, env, component, versionTag, versionBranch, versionCommitHash string) (models.FormVariables, *http.Response, error) {
 	var result models.FormVariables
 
-	if versionID == 0 {
-		// Auto-resolve latest: get the component's stack ref, then find the default catalog version.
-		// This matches console behavior which always passes ?service_catalog_source_version_id=<latest>.
-		comp, _, err := m.GetComponent(org, project, env, component)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to get component to resolve stack version: %w", err)
-		}
-		resolved, _, err := m.resolveStackVersion(org, *comp.ServiceCatalog.Ref, "", "", "")
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to resolve latest stack version: %w", err)
-		}
-		versionID = resolved
+	// Resolve component's stack ref first, then use it to find the right version.
+	// When all version args are empty this returns the default (latest branch head),
+	// matching console behavior (?service_catalog_source_version_id=<latest>).
+	comp, _, err := m.GetComponent(org, project, env, component)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get component to resolve stack version: %w", err)
+	}
+	versionID, _, err := m.resolveStackVersion(org, *comp.ServiceCatalog.Ref, versionTag, versionBranch, versionCommitHash)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to resolve stack version: %w", err)
 	}
 
 	query := url.Values{

--- a/cmd/cycloid/middleware/organization_components.go
+++ b/cmd/cycloid/middleware/organization_components.go
@@ -10,12 +10,32 @@ import (
 	"github.com/cycloidio/cycloid-cli/internal/ptr"
 )
 
-func (m *middleware) GetComponentConfig(org, project, env, component string) (models.FormVariables, *http.Response, error) {
+func (m *middleware) GetComponentConfig(org, project, env, component string, versionID uint32) (models.FormVariables, *http.Response, error) {
 	var result models.FormVariables
+
+	if versionID == 0 {
+		// Auto-resolve latest: get the component's stack ref, then find the default catalog version.
+		// This matches console behavior which always passes ?service_catalog_source_version_id=<latest>.
+		comp, _, err := m.GetComponent(org, project, env, component)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get component to resolve stack version: %w", err)
+		}
+		resolved, _, err := m.resolveStackVersion(org, *comp.ServiceCatalog.Ref, "", "", "")
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to resolve latest stack version: %w", err)
+		}
+		versionID = resolved
+	}
+
+	query := url.Values{
+		"service_catalog_source_version_id": []string{strconv.FormatUint(uint64(versionID), 10)},
+	}
+
 	resp, err := m.GenericRequest(Request{
 		Method:       "GET",
 		Organization: &org,
 		Route:        []string{"organizations", org, "projects", project, "environments", env, "components", component, "config"},
+		Query:        query,
 	}, &result)
 	if err != nil {
 		return nil, resp, err

--- a/cmd/cycloid/middleware/organization_components.go
+++ b/cmd/cycloid/middleware/organization_components.go
@@ -10,19 +10,21 @@ import (
 	"github.com/cycloidio/cycloid-cli/internal/ptr"
 )
 
-func (m *middleware) GetComponentConfig(org, project, env, component, versionTag, versionBranch, versionCommitHash string) (models.FormVariables, *http.Response, error) {
+func (m *middleware) GetComponentConfig(org, project, env, component, versionTag, versionBranch, versionCommitHash string, versionID uint32) (models.FormVariables, *http.Response, error) {
 	var result models.FormVariables
 
-	// Resolve component's stack ref first, then use it to find the right version.
-	// When all version args are empty this returns the default (latest branch head),
-	// matching console behavior (?service_catalog_source_version_id=<latest>).
-	comp, _, err := m.GetComponent(org, project, env, component)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get component to resolve stack version: %w", err)
-	}
-	versionID, _, err := m.resolveStackVersion(org, *comp.ServiceCatalog.Ref, versionTag, versionBranch, versionCommitHash)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to resolve stack version: %w", err)
+	if versionID == 0 {
+		// Resolve component's stack ref to find the right catalog version.
+		// When all version args are empty this returns the default (latest branch head),
+		// matching console behavior (?service_catalog_source_version_id=<latest>).
+		comp, _, err := m.GetComponent(org, project, env, component)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get component to resolve stack version: %w", err)
+		}
+		versionID, _, err = m.resolveStackVersion(org, *comp.ServiceCatalog.Ref, versionTag, versionBranch, versionCommitHash)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to resolve stack version: %w", err)
+		}
 	}
 
 	query := url.Values{

--- a/cmd/cycloid/projects/create.go
+++ b/cmd/cycloid/projects/create.go
@@ -74,7 +74,7 @@ func create(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	configRepository, err := cyargs.GetDefaultConfigRepository(cmd)
+	configRepository, err := cyargs.GetConfigRepository(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/cycloid/projects/update.go
+++ b/cmd/cycloid/projects/update.go
@@ -68,7 +68,7 @@ func update(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	configRepository, err := cyargs.GetDefaultConfigRepository(cmd)
+	configRepository, err := cyargs.GetConfigRepository(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/cyargs/config_catalog_repositories.go
+++ b/internal/cyargs/config_catalog_repositories.go
@@ -1,12 +1,8 @@
 package cyargs
 
 import (
-	"fmt"
-	"slices"
-
 	"github.com/spf13/cobra"
 
-	"github.com/cycloidio/cycloid-cli/client/models"
 	"github.com/cycloidio/cycloid-cli/cmd/cycloid/common"
 	"github.com/cycloidio/cycloid-cli/cmd/cycloid/middleware"
 )
@@ -71,7 +67,7 @@ func CompleteCatalogRepository(cmd *cobra.Command, args []string, toComplete str
 
 func AddConfigRepositoryFlag(cmd *cobra.Command) string {
 	flagName := "config-repository"
-	cmd.Flags().String(flagName, "", "canonical of a config repository, if empty will use the default one in the current org.")
+	cmd.Flags().String(flagName, "", "canonical of a config repository")
 	cmd.RegisterFlagCompletionFunc(flagName, CompleteConfigRepository)
 	return flagName
 }
@@ -108,8 +104,6 @@ func CompleteConfigRepository(cmd *cobra.Command, args []string, toComplete stri
 	return configRepositories, cobra.ShellCompDirectiveNoFileComp
 }
 
-// GetConfigRepository return the config repository flag, if empty, will try to return
-// the current org default config repository
 func GetConfigRepository(cmd *cobra.Command) (string, error) {
 	configRepository, err := cmd.Flags().GetString("config-repository")
 	if err != nil {
@@ -117,36 +111,4 @@ func GetConfigRepository(cmd *cobra.Command) (string, error) {
 	}
 
 	return configRepository, err
-}
-
-func GetDefaultConfigRepository(cmd *cobra.Command) (string, error) {
-	api := common.NewAPI()
-	m := middleware.NewMiddleware(api)
-
-	org, err := GetOrg(cmd)
-	if err != nil {
-		return "", fmt.Errorf("failed to get default config repository, missing org argument: %w", err)
-	}
-
-	configRepository, _ := GetConfigRepository(cmd)
-	if configRepository != "" {
-		return configRepository, nil
-	}
-
-	// TODO: This behavior will be pushed to backend
-	// track issue: https://linear.app/cycloid/issue/BE-807/make-the-createproject-route-use-the-default-catalog-if
-	catalogRepos, _, err := m.ListConfigRepositories(org)
-	if err != nil {
-		return "", fmt.Errorf("failed to get the default config repository: %w", err)
-	}
-
-	index := slices.IndexFunc(catalogRepos, func(c *models.ConfigRepository) bool {
-		return *c.Default
-	})
-	if index == -1 {
-		docURL := "https://docs.cycloid.io/reference/config-and-catalog-repository/"
-		return "", fmt.Errorf("error: seems like your org %q does not have a default config repository, please add one using this doc: %q", org, docURL)
-	}
-
-	return *catalogRepos[index].Canonical, nil
 }

--- a/internal/cyargs/stacks.go
+++ b/internal/cyargs/stacks.go
@@ -136,7 +136,7 @@ func GetStack(cmd *cobra.Command) (string, error) {
 // backward compatibility but are deprecated and will be removed in a future major release.
 func AddStackVersionFlags(cmd *cobra.Command) {
 	cmd.Flags().String("stack-version", "", "stack version (tag, branch, or commit hash). "+
-		"Use type prefixes to avoid ambiguity: tag:<name>, branch:<name>, sha:<hash>")
+		"Use type prefixes to avoid ambiguity: tag:<name>, branch:<name>, sha:<hash>, version:<id>")
 	cmd.RegisterFlagCompletionFunc("stack-version", CompleteStackVersionUnified)
 
 	// Legacy flags — kept for backward compatibility.
@@ -219,6 +219,10 @@ func ResolveStackVersionArg(cmd *cobra.Command, m middleware.Middleware, org, st
 			return "", value, "", nil
 		case "sha", "commit":
 			return "", "", value, nil
+		case "version":
+			return "", "", "", fmt.Errorf(
+				"--stack-version=version:<id> is only supported by 'cy component config get'; " +
+					"use tag:<name>, branch:<name>, or sha:<hash> for other commands")
 		}
 		// Unknown prefix: fall through and attempt bare resolution on the full value.
 	}

--- a/internal/cyargs/stacks.go
+++ b/internal/cyargs/stacks.go
@@ -2,6 +2,7 @@ package cyargs
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -268,6 +269,24 @@ func ResolveStackVersionArg(cmd *cobra.Command, m middleware.Middleware, org, st
 	default:
 		return "", "", "", fmt.Errorf("version %q not found in stack %q", v, stackRef)
 	}
+}
+
+// GetStackVersionID parses --stack-version=version:<id> and returns the numeric catalog
+// version ID. Returns (id, true, nil) when that form is used, (0, false, nil) otherwise.
+func GetStackVersionID(cmd *cobra.Command) (uint32, bool, error) {
+	v, err := cmd.Flags().GetString("stack-version")
+	if err != nil || v == "" {
+		return 0, false, err
+	}
+	idStr, ok := strings.CutPrefix(v, "version:")
+	if !ok {
+		return 0, false, nil
+	}
+	id64, err := strconv.ParseUint(idStr, 10, 32)
+	if err != nil {
+		return 0, false, fmt.Errorf("--stack-version=version:<id>: expected a numeric ID, got %q", idStr)
+	}
+	return uint32(id64), true, nil
 }
 
 // CompleteStackVersionUnified provides prefix-aware completion for --stack-version.


### PR DESCRIPTION
## Summary

- Removes `GetDefaultConfigRepository` from `internal/cyargs/` — the helper fetched the org's default config repo via the API when `--config-repository` was omitted
- Replaces both callers (`project create`, `project update`) with `GetConfigRepository` (flag-only read, returns empty string when unset)
- Cleans up now-unused imports (`fmt`, `slices`, `client/models`) from cyargs
- Updates `--config-repository` flag description and removes stale comment

## Why draft / blocked

**Blocked on BE-807** — [Make the createProject route use the default catalog if catalogRepository is empty](https://linear.app/cycloid/issue/BE-807)

BE-807 is still **Backlog**. Until it lands, passing an empty `configRepository` to the backend will fail. This PR must not be merged until BE-807 is done and deployed.

Once BE-807 is merged: remove the draft status, verify e2e `project create` without `--config-repository` works, then merge.

## Test plan

- [x] `go build ./...` green in worktree
- [x] `go vet ./...` clean
- [x] `go test ./cmd/cycloid/middleware/offline/...` green
- [ ] e2e `cy project create` without `--config-repository` — **unblock after BE-807**

Closes CLI-22 (after BE-807)

🤖 Generated with [Claude Code](https://claude.com/claude-code)