### PR TITLE
feat: default --refresh to true on catalog-repository create/update

### DIFF
--- a/cmd/cycloid/catalogrepositories/create.go
+++ b/cmd/cycloid/catalogrepositories/create.go
@@ -42,7 +42,7 @@ func NewCreateCommand() *cobra.Command {
 	cmd.Flags().String("visibility", "", "set the stacks base visibility in the catalog. accepted values are 'local', 'shared' or 'hidden' (default: local)")
 	cmd.Flags().String("team", "", "set the team canonical to be set as maintener of the stacks")
 	cmd.Flags().Bool("update", false, "update the catalog repository if it already exists")
-	cmd.Flags().Bool("refresh", false, "trigger a synchronous version re-index after create (or update) to make all branches and tags immediately resolvable")
+	cmd.Flags().Bool("refresh", true, "trigger a synchronous version re-index after create (or update) to make all branches and tags immediately resolvable")
 
 	return cmd
 }

--- a/cmd/cycloid/catalogrepositories/update.go
+++ b/cmd/cycloid/catalogrepositories/update.go
@@ -30,7 +30,7 @@ func NewUpdateCommand() *cobra.Command {
 	cmd.MarkFlagRequired(cyargs.AddNameFlag(cmd))
 	cmd.MarkFlagRequired(cyargs.AddRepoBranchFlag(cmd))
 	cmd.MarkFlagRequired(cyargs.AddRepoURLFlag(cmd))
-	cmd.Flags().Bool("refresh", false, "trigger a synchronous version re-index after update to make all branches and tags immediately resolvable")
+	cmd.Flags().Bool("refresh", true, "trigger a synchronous version re-index after update to make all branches and tags immediately resolvable")
 
 	return cmd
 }


### PR DESCRIPTION
## Summary

- Changes `--refresh` flag default from `false` to `true` on `cy catalog-repository create` and `cy catalog-repository update`
- Users get correct behavior out of the box — branches are immediately resolvable after create/update
- Users who want fire-and-forget can pass `--refresh=false`

## Related

- Follow-up to [CLI-128 / PR #461](https://github.com/cycloidio/cycloid-cli/pull/461)
- [CLI-127](https://linear.app/cycloid/issue/CLI-127/stack-branch-version-not-found-during-component-creation-via-cli)

## Test plan

- [x] Existing tests pass (they explicitly set the flag value, so default doesn't affect them)