### PR TITLE
feat(middleware): add per-org sidebar nav ordering (GetOrgNav/UpdateOrgNav)

### DIFF
--- a/cmd/cycloid/middleware/middleware.go
+++ b/cmd/cycloid/middleware/middleware.go
@@ -98,6 +98,10 @@ type Middleware interface {
 	GetOIDCIntegration(org string) (*OIDCIntegration, *http.Response, error)
 	UpdateOIDCIntegration(org string, config map[string]interface{}) (*OIDCIntegration, *http.Response, error)
 
+	// organization_nav — per-org sidebar nav ordering
+	GetOrgNav(org string) (*NavConfig, *http.Response, error)
+	UpdateOrgNav(org string, items []*NavItem) (*NavConfig, *http.Response, error)
+
 	// organizations
 	CreateOrganization(name string) (*models.Organization, *http.Response, error)
 	UpdateOrganization(org, name string) (*models.Organization, *http.Response, error)

--- a/cmd/cycloid/middleware/organization_nav.go
+++ b/cmd/cycloid/middleware/organization_nav.go
@@ -1,0 +1,64 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// NavItem is a single sidebar entry with an explicit position.
+//
+// This type lives in the middleware package (not client/models) following the
+// same convention as OIDCOrganizationSettings: the endpoint is simple enough
+// (two fields, a GET/PUT pair) that a hand-defined type plus GenericRequest is
+// more direct than swagger-driven codegen for it.
+type NavItem struct {
+	// Type is either "native" (a built-in section, identified by name, e.g.
+	// "dashboard") or "plugin_widget" (identified by the widget's plugin ID as
+	// a string).
+	Type string `json:"type"`
+	Key  string `json:"key"`
+	// Position is 1-indexed; positions must be unique within a NavConfig.
+	Position uint32 `json:"position"`
+}
+
+// NavConfig is the per-organization sidebar nav ordering configuration.
+// Items is empty when no ordering has been saved — the console falls back to
+// its default ordering in that case.
+type NavConfig struct {
+	Items []*NavItem `json:"items"`
+}
+
+// GetOrgNav returns the org's sidebar nav ordering config.
+func (m *middleware) GetOrgNav(org string) (*NavConfig, *http.Response, error) {
+	var result *NavConfig
+	resp, err := m.GenericRequest(Request{
+		Method:       "GET",
+		Organization: &org,
+		Route:        []string{"organizations", org, "nav"},
+	}, &result)
+	if err != nil {
+		return nil, resp, fmt.Errorf("failed to get organization nav ordering: %w", err)
+	}
+	return result, resp, nil
+}
+
+// UpdateOrgNav creates or replaces the org's sidebar nav ordering config.
+// Passing an empty (or nil) items slice resets the ordering to defaults.
+func (m *middleware) UpdateOrgNav(org string, items []*NavItem) (*NavConfig, *http.Response, error) {
+	body := &NavConfig{Items: items}
+	if body.Items == nil {
+		body.Items = []*NavItem{}
+	}
+
+	var result *NavConfig
+	resp, err := m.GenericRequest(Request{
+		Method:       "PUT",
+		Organization: &org,
+		Route:        []string{"organizations", org, "nav"},
+		Body:         body,
+	}, &result)
+	if err != nil {
+		return nil, resp, fmt.Errorf("failed to update organization nav ordering: %w", err)
+	}
+	return result, resp, nil
+}


### PR DESCRIPTION
## What

Client support for the nav-ordering endpoint (PROD-774): `GET`/`PUT /organizations/{org}/nav`.

`NavItem{Type, Key, Position}` and `NavConfig{Items}` mirror the backend's models exactly (`type`: `"native"` | `"plugin_widget"`, `key`, `position` uint32 >= 1). Mirrors the existing `OIDCOrganizationSettings` pattern (`cmd/cycloid/middleware/organization_oidc.go`) — a hand-defined type in the middleware package plus `GenericRequest`, rather than swagger-driven codegen, since it's a simple two-field GET/PUT pair.

`UpdateOrgNav` always sends an explicit `[]` for a nil/empty items slice, never JSON `null` — an empty array is what resets the ordering to defaults per the API contract; omitting the field or sending `null` is not the same thing.

## Dependency — please don't merge yet

The backend endpoint is currently **missing from `develop`** due to a regression: [ENGBE-282](https://linear.app/cycloid/issue/ENGBE-282). Restore PR open at cycloidio/youdeploy-http-api#5977, not yet merged. This CLI change compiles and is self-contained (it's just a client method addition), but `GetOrgNav`/`UpdateOrgNav` will 404 against a live backend until that PR merges.

## Intended consumer

A new `cycloid_organization_nav_order` resource in `terraform-provider-cycloid` ([TFPRO-55](https://linear.app/cycloid/issue/TFPRO-55)) — PR to follow this one, will point its `go.mod` at this branch until this merges.

🤖 Generated with a fleet worker session — https://claude.ai/code/session_014CST9mw3ABSA4aYHNy96EV