### PR TITLE
fix(CLI-145): nil map panic in FormUseCaseToFormVars on section/group name collision

### DIFF
--- a/cmd/common/formsUtils.go
+++ b/cmd/common/formsUtils.go
@@ -19,7 +19,7 @@ func FormUseCaseToFormVars(stackConfig models.ServiceCatalogConfigs, useCaseName
 			output[*section.Name] = make(map[string]map[string]any)
 		}
 		for _, group := range section.Groups {
-			if _, ok := output[*group.Name]; !ok {
+			if _, ok := output[*section.Name][*group.Name]; !ok {
 				output[*section.Name][*group.Name] = make(map[string]any)
 			}
 

--- a/cmd/common/formsUtils_test.go
+++ b/cmd/common/formsUtils_test.go
@@ -1,0 +1,111 @@
+package common_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cycloidio/cycloid-cli/cmd/common"
+	"github.com/cycloidio/cycloid-cli/gen/models"
+	"github.com/cycloidio/cycloid-cli/utils/ptr"
+)
+
+func TestFormUseCaseToFormVars(t *testing.T) {
+	t.Run("GroupNameEqualsSectionName", func(t *testing.T) {
+		// A group named the same as its own section used to bypass the nested
+		// map init guard (CLI-145), causing a nil map panic on write.
+		stackConfig := models.ServiceCatalogConfigs{
+			"default": models.ServiceCatalogConfig{
+				Forms: &models.FormUseCase{
+					Sections: []*models.FormSection{
+						{
+							Name: ptr.Ptr("shared"),
+							Groups: []*models.FormGroup{
+								{
+									Name: ptr.Ptr("shared"),
+									Vars: []*models.FormEntity{
+										{Key: ptr.Ptr("key1"), Default: "value1"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		var res models.FormVariables
+		var err error
+		assert.NotPanics(t, func() {
+			res, err = common.FormUseCaseToFormVars(stackConfig, "default")
+		})
+		assert.NoError(t, err)
+
+		assert.Equal(t, models.FormVariables{
+			"shared": {
+				"shared": {
+					"key1": "value1",
+				},
+			},
+		}, res)
+	})
+
+	t.Run("GroupNameCollidesWithAnotherSectionName", func(t *testing.T) {
+		// The outer output map only ever holds section names as top-level keys,
+		// so the wrong guard (output[*group.Name]) falsely reports "already
+		// initialized" whenever a group's name matches ANY already-processed
+		// section — not just its own. Reproduce with sectionB's group named
+		// after sectionA, which was already allocated by the time sectionB
+		// is processed.
+		stackConfig := models.ServiceCatalogConfigs{
+			"default": models.ServiceCatalogConfig{
+				Forms: &models.FormUseCase{
+					Sections: []*models.FormSection{
+						{
+							Name: ptr.Ptr("sectionA"),
+							Groups: []*models.FormGroup{
+								{
+									Name: ptr.Ptr("g1"),
+									Vars: []*models.FormEntity{
+										{Key: ptr.Ptr("key1"), Default: "valueA"},
+									},
+								},
+							},
+						},
+						{
+							Name: ptr.Ptr("sectionB"),
+							Groups: []*models.FormGroup{
+								{
+									Name: ptr.Ptr("sectionA"),
+									Vars: []*models.FormEntity{
+										{Key: ptr.Ptr("key1"), Default: "valueB"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		var res models.FormVariables
+		var err error
+		assert.NotPanics(t, func() {
+			res, err = common.FormUseCaseToFormVars(stackConfig, "default")
+		})
+		assert.NoError(t, err)
+
+		assert.Equal(t, models.FormVariables{
+			"sectionA": {
+				"g1": {
+					"key1": "valueA",
+				},
+			},
+			"sectionB": {
+				"sectionA": {
+					"key1": "valueB",
+				},
+			},
+		}, res)
+	})
+}


### PR DESCRIPTION
## Root cause

`FormUseCaseToFormVars` (`cmd/common/formsUtils.go`) builds a nested `section -> group -> key -> value` map. The group-level init guard checked `output[*group.Name]` — the **outer**, section-keyed map — instead of `output[*section.Name][*group.Name]`, the nested map actually being written to on the next line.

The outer map's top-level keys are only ever section names. So whenever a group's name matched *any already-processed section name* (its own section, or a prior sibling section), the guard falsely reported the nested map as already initialized, skipped allocation, and the following write panicked:

```
panic: assignment to entry in nil map

github.com/cycloidio/cycloid-cli/cmd/cycloid/common.FormUseCaseToFormVars
    cmd/cycloid/common/formsUtils.go:28
github.com/cycloidio/cycloid-cli/cmd/cycloid/stacks.getConfig
    cmd/cycloid/stacks/get_config.go:62
```

Reproduced on staging org `seraf`, project `tl-debug`, env `debug-forms`, component `debug-forms`, use case `default` (`cy stack get-config`) — a clean `200 OK` from the backend immediately followed by the panic. Backend is not involved.

Pre-existing since commit `7bd4be6f` ("fix: forms variable handling and testing", 2025-05-13), present in every release since ~v6.0.114-rc. Found while root-causing ENG-245; the other crash originally lumped into that issue is a separate, genuine backend nil deref fixed by `youdeploy-http-api/6091`.

## Fix

```go
if _, ok := output[*section.Name][*group.Name]; !ok {
    output[*section.Name][*group.Name] = make(map[string]any)
}
```

Safe because `output[*section.Name]` is always allocated by the section-level guard directly above; reading a missing key from a non-nil map does not panic.

No other occurrence of this wrong-key guard pattern exists in `formsUtils.go` or its sibling files in `cmd/common/`.

## Tests

Added `cmd/common/formsUtils_test.go` (package previously had no tests):
- `GroupNameEqualsSectionName` — group named the same as its own section.
- `GroupNameCollidesWithAnotherSectionName` — a later section's group named after an earlier, already-processed section.

Both subtests were manually verified to panic against the pre-fix code and pass against the fix.

```
=== RUN   TestFormUseCaseToFormVars
=== RUN   TestFormUseCaseToFormVars/GroupNameEqualsSectionName
=== RUN   TestFormUseCaseToFormVars/GroupNameCollidesWithAnotherSectionName
--- PASS: TestFormUseCaseToFormVars (0.00s)
    --- PASS: TestFormUseCaseToFormVars/GroupNameEqualsSectionName (0.00s)
    --- PASS: TestFormUseCaseToFormVars/GroupNameCollidesWithAnotherSectionName (0.00s)
PASS
ok  	github.com/cycloidio/cycloid-cli/cmd/common	0.003s
```

`go build ./...` and `go vet ./cmd/common/...` are clean; `golangci-lint run ./cmd/common/...` reports no issues on the touched files (2 pre-existing, unrelated errcheck findings remain in `helpers.go`).

Note: the pre-commit `make format lint` hook could not run in a fresh worktree off `develop` — `Makefile`/`.pre-commit-config.yaml` aren't tracked on `develop` (it's a stripped Copybara-sync mirror branch), a pre-existing repo condition unrelated to this change. Verified manually with `gofmt`, `go vet`, and `golangci-lint` instead.

Ref: CLI-145