### PR TITLE
test(CLI-144): lock in ServiceCatalog.dependencies contract, no source fix needed

### DIFF
--- a/gen/models/service_catalog_test.go
+++ b/gen/models/service_catalog_test.go
@@ -1,0 +1,36 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Regression test for CLI-144: backend commit 7089ff5d20 (PROD-745) changed
+// ServiceCatalog.dependencies from a list of ServiceCatalogDependency objects
+// to a list of stack canonicals ([]string). Decoding must not error on the
+// new shape.
+func TestServiceCatalog_UnmarshalJSON_Dependencies(t *testing.T) {
+	payload := []byte(`{
+		"author": "cycloid",
+		"canonical": "my-stack",
+		"directory": "my-stack",
+		"form_enabled": true,
+		"id": 1,
+		"keywords": [],
+		"latest": true,
+		"name": "My Stack",
+		"organization_canonical": "org-root",
+		"ref": "main",
+		"trusted": true,
+		"version": "1.0.0",
+		"visibility": "shared",
+		"dependencies": ["stack-a", "stack-b"]
+	}`)
+
+	var sc ServiceCatalog
+	err := json.Unmarshal(payload, &sc)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"stack-a", "stack-b"}, sc.Dependencies)
+}


### PR DESCRIPTION
## Root cause (CLI-144)

Backend commit `7089ff5d20` (PROD-745, "stack dependency availability rules", merged 2026-07-10) changed `ServiceCatalog.dependencies` from `[]*ServiceCatalogDependency` (objects) to `[]string` (stack canonicals). Against a backend running that change, a CLI decoding the old shape crashes:

```
Error: failed to list stacks from API: failed to decode JSON response (HTTP 200):
json: cannot unmarshal string into Go struct field ServiceCatalog.dependencies
of type models.ServiceCatalogDependency
```

## What this PR actually does

Investigation found the CLI model is **already fixed on `develop`**: the automated Copybara sync from `youdeploy-http-api` (commit `bef818fa`, 2026-07-14) already brought `gen/models/service_catalog.go`'s `Dependencies` field in line with the new `[]string` contract, four days after the backend change merged. `git grep` across the repo (including vendor) turns up no remaining `ServiceCatalogDependency` type or any code path still assuming the old object shape — `go build ./...` and `go test ./...` are clean on top of this branch.

So there is no source fix to make here. This PR adds a regression test (`gen/models/service_catalog_test.go`) that decodes a `dependencies: []string` payload into `models.ServiceCatalog`, to lock in the current contract and catch any future regen drift.

## Why the bug still reproduces on staging today

The last cut CLI release tag is `v6.10.194-rc` (2026-07-02), which predates the Copybara sync that landed the fix (2026-07-14). Every fielded `cy` binary up to and including that tag still decodes the old object shape, so `cy stack list` / `cy stack get-config` will keep crashing against any backend at or above v6.10.263 (where PROD-745 ships) until a new CLI release is cut off current `develop`. **Release-notes flag:** call this out when v6.10.263 ships — older `cy` binaries need a corresponding CLI release before/alongside it, or this regression re-surfaces for every customer still on an older `cy`.

## Follow-up (not in this PR)

`cy stack list` currently does a single-pass unmarshal of the whole service catalog array, so one undecodable entry aborts the entire list. Per the CLI-144 discussion, the CLI should degrade gracefully (skip and warn) instead of hard-aborting — tracked as a follow-up, not implemented here since the immediate contract mismatch has no code path left to fix.

CLI-144